### PR TITLE
Optimization

### DIFF
--- a/platform/android/jni/bypass.cpp
+++ b/platform/android/jni/bypass.cpp
@@ -20,12 +20,14 @@ jobject recurseElement(JNIEnv *env, Bypass::Element element) {
 	jstring text = env->NewStringUTF(element.getText().c_str());
 	jobject jelement = env->NewObject(java_element_class, java_element_init, text, element.getType(), elements);
 	env->DeleteLocalRef(text);
-	std::set<std::string> attrNames = element.getAttributeNames();
-	for (std::set<std::string>::iterator it = attrNames.begin(); it != attrNames.end(); ++it) {
-		jstring name = env->NewStringUTF(it->c_str());
-		std::string strValue = element.getAttribute(*it);
-		jstring value = env->NewStringUTF(strValue.c_str());
+
+	Bypass::Element::AttributeMap::iterator it = element.attrBegin();
+	for (; it != element.attrEnd(); ++it) {
+		jstring name = env->NewStringUTF(it->first.c_str());
+		jstring value = env->NewStringUTF(it->second.c_str());
+
 		env->CallVoidMethod(jelement, java_element_addAttr, name, value);
+
 		env->DeleteLocalRef(name);
 		env->DeleteLocalRef(value);
 	}

--- a/platform/android/src/in/uncod/android/bypass/Element.java
+++ b/platform/android/src/in/uncod/android/bypass/Element.java
@@ -65,7 +65,7 @@ public class Element {
 	public void addAttribute(String name, String value) {
 		attributes.put(name, value);
 	}
-	
+
 	public String getAttribute(String name) {
 		return attributes.get(name);
 	}

--- a/platform/ios/Bypass/Bypass/BPElement.mm
+++ b/platform/ios/Bypass/Bypass/BPElement.mm
@@ -89,27 +89,20 @@ const BPElementType BPText           = Bypass::TEXT;
     using namespace std;
     
     if (_attributes == nil) {
-        set<string> attrNames = _element.getAttributeNames();
-        set<string>::iterator itr;
+		Bypass::AttributeMap::iterator it = _element.attrBegin();
+        NSMutableDictionary *attributes = [NSMutableDictionary dictionaryWithCapacity:_element.attrSize()];
 
-        NSMutableDictionary *attributes = [NSMutableDictionary dictionaryWithCapacity:attrNames.size()];
-        
-        for (itr = attrNames.begin(); itr != attrNames.end(); ++itr) {
-            string n = *itr;
-            string v = _element.getAttribute(n);
-            
-            if (n.length() > 0 && v.length() > 0) {
-                NSString *nn = [NSString stringWithCString:n.c_str() encoding:NSUTF8StringEncoding];
-                NSString *vv = [NSString stringWithCString:v.c_str() encoding:NSUTF8StringEncoding];
-                
-                attributes[nn] = vv;
-            }
-        }
-        
+		for (; it != _element.attrEnd(); ++it) {
+			if (!it->first.empty() && !it->second.empty()) {
+				NSString *nn = [NSString stringWithUTF8String:it->first.c_str()];
+				NSString *vv = [NSString stringWithUTF8String:it->second.c_str()];
+
+				[attributes setObject:vv forKey:nn];
+			}
+		}
+
         _attributes = [NSDictionary dictionaryWithDictionary:attributes];
     }
-    
-    return _attributes;
 }
 
 - (NSArray *)childElements

--- a/src/element.cpp
+++ b/src/element.cpp
@@ -13,43 +13,40 @@ namespace Bypass {
 
 	}
 
-	void Element::setText(std::string text) {
+	void Element::setText(const std::string& text) {
 		this->text = text;
 	}
 
-	std::string Element::getText() {
+	const std::string& Element::getText() {
 		return text;
 	}
 
-	void Element::addAttribute(std::string name, std::string value) {
-		attributes[name] = value;
+	void Element::addAttribute(const std::string& name, const std::string& value) {
+		attributes.insert(std::make_pair(name, value));
 	}
 
-	std::string Element::getAttribute(std::string name) {
+	std::string Element::getAttribute(const std::string& name) {
 		return attributes[name];
 	}
 
-	std::set<std::string> Element::getAttributeNames() {
-		std::set<std::string> attributeNames;
-		std::map<std::string, std::string>::iterator itr;
-
-		for(itr = attributes.begin(); itr != attributes.end(); itr++) {
-			attributeNames.insert(itr->first);
-		}
-
-		return attributeNames;
+	Element::AttributeMap::iterator Element::attrBegin() {
+		return attributes.begin();
 	}
 
-	void  Element::append(const Element& child) {
+	Element::AttributeMap::iterator Element::attrEnd() {
+		return attributes.end();
+	}
+	
+	size_t Element::attrSize() const {
+		return attributes.size();
+	}
+
+	void Element::append(const Element& child) {
 		children.push_back(Element(child));
 	}
 
 	Element Element::operator[](size_t i) {
 		return children[i];
-	}
-
-	void Element::setChildren(std::vector<Element> children) {
-		this->children.insert(this->children.end(), children.begin(), children.end());
 	}
 
 	void Element::setType(Type type) {

--- a/src/element.h
+++ b/src/element.h
@@ -43,17 +43,26 @@ namespace Bypass {
 
 	class Element {
 	public:
+		typedef std::map<std::string, std::string> AttributeMap;
+
 		Element();
 		~Element();
-		void setText(std::string text);
-		std::string getText();
-		void addAttribute(std::string name, std::string value);
-		std::string getAttribute(std::string name);
-		std::set<std::string> getAttributeNames();
+
+		std::string text;
+
+		void setText(const std::string& text);
+		const std::string& getText();
+
+		void addAttribute(const std::string& name, const std::string& value);
+		std::string getAttribute(const std::string& name);
+
+		AttributeMap::iterator attrBegin();
+		AttributeMap::iterator attrEnd();
+		size_t attrSize() const;
+
 		void append(const Element& blockElement);
 		Element getChild(size_t i);
 		Element operator[](size_t i);
-		void setChildren(std::vector<Element> children);
 		void setType(Type type);
 		Type getType();
 		bool isBlockElement();
@@ -61,8 +70,7 @@ namespace Bypass {
 		size_t size();
 		friend std::ostream& operator<<(std::ostream& out, const Element& element);
 	private:
-		std::string text;
-		std::map<std::string, std::string> attributes;
+		AttributeMap attributes;
 		std::vector<Element> children;
 		Type type;
 	};

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -101,20 +101,14 @@ namespace Bypass {
 		return parse(markdown.c_str());
 	}
 
-	void Parser::eraseTrailingControlCharacters(std::string controlCharacters) {
+	void Parser::eraseTrailingControlCharacters(const std::string& controlCharacters) {
 		std::map<int, Element>::iterator it = elementSoup.find(elementCount);
-		Element* element = NULL;
 
 		if ( it != elementSoup.end() ) {
-			element = &((*it).second);
-			std::string precedingText = element->getText();
-			size_t ptlen = precedingText.length();
-			size_t cclen = controlCharacters.length();
+			Element * element = &((*it).second);
 
-			if (ptlen > cclen) {
-				if (precedingText.substr(ptlen - cclen) == controlCharacters) {
-					element->setText(precedingText.substr(0, ptlen - cclen));
-				}
+			if (boost::ends_with(element->text, controlCharacters)) {
+				boost::erase_tail(element->text, controlCharacters.size());
 			}
 		}
 	}
@@ -227,7 +221,7 @@ namespace Bypass {
 		}
 	}
 
-	void Parser::createSpan(Element element, struct buf *ob) {
+	void Parser::createSpan(const Element& element, struct buf *ob) {
 		elementCount++;
 		std::ostringstream oss;
 		oss << elementCount;
@@ -260,7 +254,7 @@ namespace Bypass {
 		if (text && text->size > 0) {
 			Element codeSpan;
 			codeSpan.setType(CODE_SPAN);
-			codeSpan.setText(std::string(text->data, text->data + text->size));
+			codeSpan.text.assign(text->data, text->data + text->size);
 			createSpan(codeSpan, ob);
 		}
 		return 1;
@@ -281,7 +275,7 @@ namespace Bypass {
 		if (text && text->size > 0) {
 			Element normalText;
 			normalText.setType(TEXT);
-			normalText.setText(std::string(text->data, text->data + text->size));
+			normalText.text.assign(text->data, text->data + text->size);
 			createSpan(normalText, ob);
 		}
 	}

--- a/src/parser.h
+++ b/src/parser.h
@@ -62,8 +62,8 @@ namespace Bypass {
 		int elementCount;
 		void handleBlock(Type, struct buf *ob, struct buf *text, int extra = -1);
 		void handleSpan(Type, struct buf *ob, struct buf *text, struct buf *extra = NULL, struct buf *extra2 = NULL);
-		void createSpan(Element, struct buf *ob);
-		void eraseTrailingControlCharacters(std::string controlCharacters);
+		void createSpan(const Element&, struct buf *ob);
+		void eraseTrailingControlCharacters(const std::string& controlCharacters);
 	};
 
 }

--- a/test/element_tests.cpp
+++ b/test/element_tests.cpp
@@ -177,7 +177,6 @@ BOOST_FIXTURE_TEST_CASE(element_access_single, F) {
 
 	Element child;
 	child.setText(expected);
-
 	BOOST_REQUIRE(child.getText() == expected);
 
 	element.append(child);
@@ -215,17 +214,21 @@ BOOST_FIXTURE_TEST_CASE(element_get_attribute, F) {
 }
 
 BOOST_FIXTURE_TEST_CASE(element_get_attribute_names_with_no_attributes, F) {
-	BOOST_REQUIRE(element.getAttributeNames().size() == 0);
+	BOOST_REQUIRE(element.attrSize() == 0);
 }
 
 BOOST_FIXTURE_TEST_CASE(element_get_attribute_names_with_multiple_attributes, F) {
 	element.addAttribute("a", "A");
 	element.addAttribute("b", "B");
 
-	std::set<std::string> ns = element.getAttributeNames();
+	std::set<std::string> res; 
+	Element::AttributeMap::iterator it = element.attrBegin();
+	for (; it != element.attrEnd(); ++it) {
+		res.insert(it->first);
+	}
 
-	BOOST_REQUIRE(ns.size() == 2);
-	BOOST_REQUIRE(std::find(ns.begin(), ns.end(), "a") != ns.end());
-	BOOST_REQUIRE(std::find(ns.begin(), ns.end(), "b") != ns.end());
+	BOOST_REQUIRE(res.size() == 2);
+	BOOST_REQUIRE(std::find(res.begin(), res.end(), "a") != res.end());
+	BOOST_REQUIRE(std::find(res.begin(), res.end(), "b") != res.end());
 }
 

--- a/test/parser_tests.cpp
+++ b/test/parser_tests.cpp
@@ -208,7 +208,7 @@ BOOST_FIXTURE_TEST_CASE(parse_link_with_simple_example, F) {
 	BOOST_REQUIRE(document[0][0].getType() == LINK);
 	BOOST_REQUIRE(document[0][0].getText() == "one");
 	BOOST_REQUIRE(document[0][0].getAttribute("link") == "http://example.net/");
-	BOOST_REQUIRE(document[0][0].getAttributeNames().size() == 1);
+	BOOST_REQUIRE(document[0][0].attrSize() == 1);
 	BOOST_REQUIRE(document[0][0].size() == 0);
 }
 
@@ -223,7 +223,7 @@ BOOST_FIXTURE_TEST_CASE(parse_link_with_simple_titled_example, F) {
 	BOOST_REQUIRE(document[0][0].getText() == "one");
 	BOOST_REQUIRE(document[0][0].getAttribute("link") == "http://example.net/");
 	BOOST_REQUIRE(document[0][0].getAttribute("title") == "One");
-	BOOST_REQUIRE(document[0][0].getAttributeNames().size() == 2);
+	BOOST_REQUIRE(document[0][0].attrSize() == 2);
 	BOOST_REQUIRE(document[0][0].size() == 0);
 }
 
@@ -240,7 +240,7 @@ BOOST_FIXTURE_TEST_CASE(parse_link_with_single_interspersed_simple_example, F) {
 	BOOST_REQUIRE(document[0][1].getType() == LINK);
 	BOOST_REQUIRE(document[0][1].getText() == "two");
 	BOOST_REQUIRE(document[0][1].getAttribute("link") == "http://example.net/");
-	BOOST_REQUIRE(document[0][1].getAttributeNames().size() == 1);
+	BOOST_REQUIRE(document[0][1].attrSize() == 1);
 	BOOST_REQUIRE(document[0][1].size() == 0);
 	BOOST_REQUIRE(document[0][2].getType() == TEXT);
 	BOOST_REQUIRE(document[0][2].getText() == " three");
@@ -262,7 +262,7 @@ BOOST_FIXTURE_TEST_CASE(parse_link_with_single_interspersed_simple_titled_exampl
 	BOOST_REQUIRE(document[0][1].getText() == "two");
 	BOOST_REQUIRE(document[0][1].getAttribute("link") == "http://example.net/");
 	BOOST_REQUIRE(document[0][1].getAttribute("title") == "Two");
-	BOOST_REQUIRE(document[0][1].getAttributeNames().size() == 2);
+	BOOST_REQUIRE(document[0][1].attrSize() == 2);
 	BOOST_REQUIRE(document[0][1].size() == 0);
 	BOOST_REQUIRE(document[0][2].getType() == TEXT);
 	BOOST_REQUIRE(document[0][2].getText() == " three");
@@ -280,7 +280,7 @@ BOOST_FIXTURE_TEST_CASE(parse_link_with_multiple_interspersed_simple_example, F)
 	BOOST_REQUIRE(document[0][0].getType() == LINK);
 	BOOST_REQUIRE(document[0][0].getText() == "one");
 	BOOST_REQUIRE(document[0][0].getAttribute("link") == "http://example.net/");
-	BOOST_REQUIRE(document[0][0].getAttributeNames().size() == 1);
+	BOOST_REQUIRE(document[0][0].attrSize() == 1);
 	BOOST_REQUIRE(document[0][0].size() == 0);
 	BOOST_REQUIRE(document[0][1].getType() == TEXT);
 	BOOST_REQUIRE(document[0][1].getText() == " two ");
@@ -288,7 +288,7 @@ BOOST_FIXTURE_TEST_CASE(parse_link_with_multiple_interspersed_simple_example, F)
 	BOOST_REQUIRE(document[0][2].getType() == LINK);
 	BOOST_REQUIRE(document[0][2].getText() == "three");
 	BOOST_REQUIRE(document[0][2].getAttribute("link") == "http://example.net/");
-	BOOST_REQUIRE(document[0][2].getAttributeNames().size() == 1);
+	BOOST_REQUIRE(document[0][2].attrSize() == 1);
 	BOOST_REQUIRE(document[0][2].size() == 0);
 }
 
@@ -305,7 +305,7 @@ BOOST_FIXTURE_TEST_CASE(parse_link_with_multiple_interspersed_simple_titled_exam
 	BOOST_REQUIRE(document[0][0].getText() == "one");
 	BOOST_REQUIRE(document[0][0].getAttribute("link") == "http://example.net/");
 	BOOST_REQUIRE(document[0][0].getAttribute("title") == "One");
-	BOOST_REQUIRE(document[0][0].getAttributeNames().size() == 2);
+	BOOST_REQUIRE(document[0][0].attrSize() == 2);
 	BOOST_REQUIRE(document[0][0].size() == 0);
 	BOOST_REQUIRE(document[0][1].getType() == TEXT);
 	BOOST_REQUIRE(document[0][1].getText() == " two ");
@@ -314,7 +314,7 @@ BOOST_FIXTURE_TEST_CASE(parse_link_with_multiple_interspersed_simple_titled_exam
 	BOOST_REQUIRE(document[0][2].getText() == "three");
 	BOOST_REQUIRE(document[0][2].getAttribute("link") == "http://example.net/");
 	BOOST_REQUIRE(document[0][2].getAttribute("title") == "Three");
-	BOOST_REQUIRE(document[0][2].getAttributeNames().size() == 2);
+	BOOST_REQUIRE(document[0][2].attrSize() == 2);
 	BOOST_REQUIRE(document[0][2].size() == 0);
 }
 


### PR DESCRIPTION
More const references.
Removing getAttributeNames, exposing iterators and size instead.
Avoid copies by assigning to text.
