### PR TITLE
Tweaking header sizes

### DIFF
--- a/platform/ios/Bypass/Bypass/BPAttributedStringConverter.m
+++ b/platform/ios/Bypass/Bypass/BPAttributedStringConverter.m
@@ -153,7 +153,7 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
 {
     if (_h1Font == NULL) {
         _h1Font = CTFontCreateWithName(CFSTR("HelveticaNeue-CondensedBold"),
-                                       CTFontGetSize([self defaultFont]) * 1.5, NULL);
+                                       CTFontGetSize([self defaultFont]) * 2, NULL);
     }
     
     return _h1Font;
@@ -163,7 +163,7 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
 {
     if (_h2Font == NULL) {
         _h2Font = CTFontCreateWithName(CFSTR("HelveticaNeue-CondensedBold"),
-                                       CTFontGetSize([self defaultFont]) * 1.4, NULL);
+                                       CTFontGetSize([self defaultFont]) * 1.8, NULL);
     }
     
     return _h2Font;
@@ -173,7 +173,7 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
 {
     if (_h3Font == NULL) {
         _h3Font = CTFontCreateWithName(CFSTR("HelveticaNeue-CondensedBold"),
-                                       CTFontGetSize([self defaultFont]) * 1.3, NULL);
+                                       CTFontGetSize([self defaultFont]) * 1.6, NULL);
     }
     
     return _h3Font;
@@ -183,7 +183,7 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
 {
     if (_h4Font == NULL) {
         _h4Font = CTFontCreateWithName(CFSTR("HelveticaNeue-CondensedBold"),
-                                       CTFontGetSize([self defaultFont]) * 1.2, NULL);
+                                       CTFontGetSize([self defaultFont]) * 1.4, NULL);
     }
     
     return _h4Font;
@@ -193,7 +193,7 @@ static const CGFloat kParagraphSpacingNone  =  0.0f;
 {
     if (_h5Font == NULL) {
         _h5Font = CTFontCreateWithName(CFSTR("HelveticaNeue-CondensedBold"),
-                                       CTFontGetSize([self defaultFont]) * 1.1, NULL);
+                                       CTFontGetSize([self defaultFont]) * 1.2, NULL);
     }
     
     return _h5Font;

--- a/platform/ios/BypassSample/BypassSample/sample.markdown
+++ b/platform/ios/BypassSample/BypassSample/sample.markdown
@@ -1,8 +1,64 @@
-#Bypass
+# Bypass
 
-#Header sizes
-##Smaller header
-###Even smaller header
+The following shows the size of the headers.
+
+# Header sizes
+## Smaller header
+### Even smaller
+#### Even smaller and smaller
+##### Even smaller and smaller and smaller
+###### Even smaller and smaller...you get the point
+
+Now, the following will show the same headers amongst paragraphs of text.
+
+# Header sizes
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ullamcorper tempus neque vulputate congue.
+Quisque ipsum tellus, pharetra vitae dictum sit amet, placerat vitae felis. Etiam ornare eleifend libero,
+et dignissim nibh rhoncus eu. Morbi mattis nisi in velit tristique eu mollis odio molestie.
+Phasellus pretium dapibus mattis. Nullam mollis nisl id enim vestibulum quis lacinia turpis pellentesque.
+Integer id mi quam. Fusce sagittis cursus eros, nec convallis ligula consectetur quis. Suspendisse potenti.
+
+## Smaller header
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ullamcorper tempus neque vulputate congue.
+Quisque ipsum tellus, pharetra vitae dictum sit amet, placerat vitae felis. Etiam ornare eleifend libero,
+et dignissim nibh rhoncus eu. Morbi mattis nisi in velit tristique eu mollis odio molestie.
+Phasellus pretium dapibus mattis. Nullam mollis nisl id enim vestibulum quis lacinia turpis pellentesque.
+Integer id mi quam. Fusce sagittis cursus eros, nec convallis ligula consectetur quis. Suspendisse potenti.
+
+### Even smaller
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ullamcorper tempus neque vulputate congue.
+Quisque ipsum tellus, pharetra vitae dictum sit amet, placerat vitae felis. Etiam ornare eleifend libero,
+et dignissim nibh rhoncus eu. Morbi mattis nisi in velit tristique eu mollis odio molestie.
+Phasellus pretium dapibus mattis. Nullam mollis nisl id enim vestibulum quis lacinia turpis pellentesque.
+Integer id mi quam. Fusce sagittis cursus eros, nec convallis ligula consectetur quis. Suspendisse potenti.
+
+#### Even smaller and smaller
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ullamcorper tempus neque vulputate congue.
+Quisque ipsum tellus, pharetra vitae dictum sit amet, placerat vitae felis. Etiam ornare eleifend libero,
+et dignissim nibh rhoncus eu. Morbi mattis nisi in velit tristique eu mollis odio molestie.
+Phasellus pretium dapibus mattis. Nullam mollis nisl id enim vestibulum quis lacinia turpis pellentesque.
+Integer id mi quam. Fusce sagittis cursus eros, nec convallis ligula consectetur quis. Suspendisse potenti.
+
+##### Even smaller and smaller and smaller
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ullamcorper tempus neque vulputate congue.
+Quisque ipsum tellus, pharetra vitae dictum sit amet, placerat vitae felis. Etiam ornare eleifend libero,
+et dignissim nibh rhoncus eu. Morbi mattis nisi in velit tristique eu mollis odio molestie.
+Phasellus pretium dapibus mattis. Nullam mollis nisl id enim vestibulum quis lacinia turpis pellentesque.
+Integer id mi quam. Fusce sagittis cursus eros, nec convallis ligula consectetur quis. Suspendisse potenti.
+
+###### Even smaller and smaller...you get the point
+
+Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nam ullamcorper tempus neque vulputate congue.
+Quisque ipsum tellus, pharetra vitae dictum sit amet, placerat vitae felis. Etiam ornare eleifend libero,
+et dignissim nibh rhoncus eu. Morbi mattis nisi in velit tristique eu mollis odio molestie.
+Phasellus pretium dapibus mattis. Nullam mollis nisl id enim vestibulum quis lacinia turpis pellentesque.
+Integer id mi quam. Fusce sagittis cursus eros, nec convallis ligula consectetur quis. Suspendisse potenti.
+
+## What Else is Supported?
 
 Paragraphs are obviously supported along with all the fancy text styling you could want.
 There is *italic*, **bold** and ***bold italic***. Even links are supported, visit the


### PR DESCRIPTION
This changes the headers sizes to span from 1.0 to 2.0 times the
size of the default font.

Here's what it looks like now:

![Screenshot 2013 03 21 10 53 41](https://f.cloud.github.com/assets/126398/286571/b4435c50-923f-11e2-814f-5fb6f2709f7d.png)
