### PR TITLE
Fix crash when tap on empty UITextView

### DIFF
--- a/platform/ios/BypassSample/BypassSample/BPTextViewController.mm
+++ b/platform/ios/BypassSample/BypassSample/BPTextViewController.mm
@@ -47,12 +47,15 @@
     // Seek out a bypass link attribute. The attributed string renderer will embed the URL
     // as a string into the attributes dictionary of a link.
     
-    NSDictionary *attributes = [[self  attributedText] attributesAtIndex:characterIndex effectiveRange:&effectiveRange];
-    NSString *linkHREF = attributes[BPLinkStyleAttributeName];
-    
-    if (linkHREF != nil) {
-        NSURL *linkURL = [NSURL URLWithString:linkHREF];
-        [[UIApplication sharedApplication] openURL:linkURL];
+    if ([self attributedText].length != 0 ) {
+        
+        NSDictionary *attributes = [[self  attributedText] attributesAtIndex:characterIndex effectiveRange:&effectiveRange];
+        NSString *linkHREF = attributes[BPLinkStyleAttributeName];
+        
+        if (linkHREF != nil) {
+            NSURL *linkURL = [NSURL URLWithString:linkHREF];
+            [[UIApplication sharedApplication] openURL:linkURL];
+        }
     }
 }
 


### PR DESCRIPTION
Well, in this case, I think we should have to check UITextView is not empty at first.
Otherwise, this will causes an exception:
`'NSRangeException', reason: 'NSRLEArray objectAtIndex:effectiveRange:: Out of bounds'`
