### PR TITLE
Implement visitor pattern for Markdown rendering in iOS

### DIFF
--- a/platform/ios/Bypass/Bypass.xcodeproj/project.pbxproj
+++ b/platform/ios/Bypass/Bypass.xcodeproj/project.pbxproj
@@ -8,6 +8,9 @@
 
 /* Begin PBXBuildFile section */
 		5E007AEB16FA17D200F8CFFD /* BPMarkdownView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E007AEA16FA17D100F8CFFD /* BPMarkdownView.m */; };
+		5E3C9F7C16FCC424000384CB /* BPElementWalker.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E3C9F7B16FCC424000384CB /* BPElementWalker.m */; };
+		5E3C9F7E16FCCF2A000384CB /* BPElementWalkerTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5E3C9F7D16FCCF2A000384CB /* BPElementWalkerTests.mm */; };
+		5E3C9F8416FCD2F7000384CB /* BPWalkEventAccumulator.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E3C9F8316FCD2F7000384CB /* BPWalkEventAccumulator.m */; };
 		5E5BC81C16E004FA00165503 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E5BC81B16E004FA00165503 /* Foundation.framework */; };
 		5E5BC82116E004FA00165503 /* Bypass.h in CopyFiles */ = {isa = PBXBuildFile; fileRef = 5E5BC82016E004FA00165503 /* Bypass.h */; };
 		5E5BC82B16E004FA00165503 /* SenTestingKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E5BC82A16E004FA00165503 /* SenTestingKit.framework */; };
@@ -29,6 +32,12 @@
 		5E5BC89B16E79B6200165503 /* element.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5E5BC89616E79B6200165503 /* element.cpp */; };
 		5E5BC89C16E79B6200165503 /* parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 5E5BC89816E79B6200165503 /* parser.cpp */; };
 		5E5BC8A116E7BE9400165503 /* CoreText.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E5BC8A016E7BE9400165503 /* CoreText.framework */; };
+		5E993C1C16FCF92800120305 /* BPTextVisitor.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E993C1B16FCF92800120305 /* BPTextVisitor.m */; };
+		5E993C2016FCFB1000120305 /* BPTextVisitorTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5E993C1F16FCFB1000120305 /* BPTextVisitorTests.mm */; };
+		5E993C2316FD00C200120305 /* BPAccessibilityVisitor.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E993C2216FD00C200120305 /* BPAccessibilityVisitor.m */; };
+		5E993C2616FD027300120305 /* BPAccessibilityElement.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E993C2516FD027300120305 /* BPAccessibilityElement.m */; };
+		5E993C2816FD183C00120305 /* BPAccessibilityVisitorTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5E993C2716FD183C00120305 /* BPAccessibilityVisitorTests.mm */; };
+		5E993C2916FD197300120305 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E5BC84F16E005E700165503 /* UIKit.framework */; };
 		6BE4F72716F0E9D100670C16 /* BPMarkdownPageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BE4F72616F0E9D100670C16 /* BPMarkdownPageView.m */; };
 /* End PBXBuildFile section */
 
@@ -58,6 +67,11 @@
 /* Begin PBXFileReference section */
 		5E007AE916FA17D100F8CFFD /* BPMarkdownView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPMarkdownView.h; sourceTree = "<group>"; };
 		5E007AEA16FA17D100F8CFFD /* BPMarkdownView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPMarkdownView.m; sourceTree = "<group>"; };
+		5E3C9F7A16FCC424000384CB /* BPElementWalker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPElementWalker.h; sourceTree = "<group>"; };
+		5E3C9F7B16FCC424000384CB /* BPElementWalker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPElementWalker.m; sourceTree = "<group>"; };
+		5E3C9F7D16FCCF2A000384CB /* BPElementWalkerTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BPElementWalkerTests.mm; sourceTree = "<group>"; };
+		5E3C9F8216FCD2F7000384CB /* BPWalkEventAccumulator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPWalkEventAccumulator.h; sourceTree = "<group>"; };
+		5E3C9F8316FCD2F7000384CB /* BPWalkEventAccumulator.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPWalkEventAccumulator.m; sourceTree = "<group>"; };
 		5E5BC81816E004FA00165503 /* libBypass.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libBypass.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		5E5BC81B16E004FA00165503 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		5E5BC81F16E004FA00165503 /* Bypass-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Bypass-Prefix.pch"; sourceTree = "<group>"; };
@@ -93,6 +107,14 @@
 		5E5BC89816E79B6200165503 /* parser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = parser.cpp; path = ../../../../src/parser.cpp; sourceTree = "<group>"; };
 		5E5BC89916E79B6200165503 /* parser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = parser.h; path = ../../../../src/parser.h; sourceTree = "<group>"; };
 		5E5BC8A016E7BE9400165503 /* CoreText.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreText.framework; path = System/Library/Frameworks/CoreText.framework; sourceTree = SDKROOT; };
+		5E993C1A16FCF92800120305 /* BPTextVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPTextVisitor.h; sourceTree = "<group>"; };
+		5E993C1B16FCF92800120305 /* BPTextVisitor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPTextVisitor.m; sourceTree = "<group>"; };
+		5E993C1F16FCFB1000120305 /* BPTextVisitorTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BPTextVisitorTests.mm; sourceTree = "<group>"; };
+		5E993C2116FD00C200120305 /* BPAccessibilityVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPAccessibilityVisitor.h; sourceTree = "<group>"; };
+		5E993C2216FD00C200120305 /* BPAccessibilityVisitor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPAccessibilityVisitor.m; sourceTree = "<group>"; };
+		5E993C2416FD027300120305 /* BPAccessibilityElement.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPAccessibilityElement.h; sourceTree = "<group>"; };
+		5E993C2516FD027300120305 /* BPAccessibilityElement.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPAccessibilityElement.m; sourceTree = "<group>"; };
+		5E993C2716FD183C00120305 /* BPAccessibilityVisitorTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BPAccessibilityVisitorTests.mm; sourceTree = "<group>"; };
 		6BE4F72516F0E9D100670C16 /* BPMarkdownPageView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPMarkdownPageView.h; sourceTree = "<group>"; };
 		6BE4F72616F0E9D100670C16 /* BPMarkdownPageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPMarkdownPageView.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -112,8 +134,9 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				5E5BC82B16E004FA00165503 /* SenTestingKit.framework in Frameworks */,
 				5E5BC82E16E004FA00165503 /* Foundation.framework in Frameworks */,
+				5E993C2916FD197300120305 /* UIKit.framework in Frameworks */,
+				5E5BC82B16E004FA00165503 /* SenTestingKit.framework in Frameworks */,
 				5E5BC83116E004FA00165503 /* libBypass.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -177,9 +200,13 @@
 		5E5BC83216E004FA00165503 /* BypassTests */ = {
 			isa = PBXGroup;
 			children = (
+				5E993C1E16FCFAFB00120305 /* Visitor Tests */,
 				5E5BC87A16E11F7300165503 /* BPElementTests.mm */,
 				5E5BC87E16E134C200165503 /* BPDocumentTests.mm */,
+				5E3C9F7D16FCCF2A000384CB /* BPElementWalkerTests.mm */,
 				5E5BC88116E1448C00165503 /* BPParserTests.m */,
+				5E3C9F8216FCD2F7000384CB /* BPWalkEventAccumulator.h */,
+				5E3C9F8316FCD2F7000384CB /* BPWalkEventAccumulator.m */,
 				5E5BC83316E004FA00165503 /* Supporting Files */,
 			);
 			path = BypassTests;
@@ -220,14 +247,39 @@
 			name = Soldout;
 			sourceTree = "<group>";
 		};
+		5E993C1D16FCF9CA00120305 /* Visitors */ = {
+			isa = PBXGroup;
+			children = (
+				5E993C2416FD027300120305 /* BPAccessibilityElement.h */,
+				5E993C2516FD027300120305 /* BPAccessibilityElement.m */,
+				5E993C2116FD00C200120305 /* BPAccessibilityVisitor.h */,
+				5E993C2216FD00C200120305 /* BPAccessibilityVisitor.m */,
+				5E993C1A16FCF92800120305 /* BPTextVisitor.h */,
+				5E993C1B16FCF92800120305 /* BPTextVisitor.m */,
+			);
+			name = Visitors;
+			sourceTree = "<group>";
+		};
+		5E993C1E16FCFAFB00120305 /* Visitor Tests */ = {
+			isa = PBXGroup;
+			children = (
+				5E993C1F16FCFB1000120305 /* BPTextVisitorTests.mm */,
+				5E993C2716FD183C00120305 /* BPAccessibilityVisitorTests.mm */,
+			);
+			name = "Visitor Tests";
+			sourceTree = "<group>";
+		};
 		6BE4F72216F0E90500670C16 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				5E993C1D16FCF9CA00120305 /* Visitors */,
 				5E5BC88516E15C5800165503 /* BPAttributedStringConverter.h */,
 				5E5BC88616E15C5800165503 /* BPAttributedStringConverter.m */,
 				5E5BC87116E0083D00165503 /* BPDocument.h */,
 				5E5BC87216E0083D00165503 /* BPDocument.mm */,
 				5E5BC87D16E12E3100165503 /* BPDocumentPrivate.h */,
+				5E3C9F7A16FCC424000384CB /* BPElementWalker.h */,
+				5E3C9F7B16FCC424000384CB /* BPElementWalker.m */,
 				5E5BC87416E0085000165503 /* BPElement.h */,
 				5E5BC87516E0085000165503 /* BPElement.mm */,
 				5E5BC87C16E1222A00165503 /* BPElementPrivate.h */,
@@ -356,6 +408,10 @@
 				5E5BC89C16E79B6200165503 /* parser.cpp in Sources */,
 				6BE4F72716F0E9D100670C16 /* BPMarkdownPageView.m in Sources */,
 				5E007AEB16FA17D200F8CFFD /* BPMarkdownView.m in Sources */,
+				5E3C9F7C16FCC424000384CB /* BPElementWalker.m in Sources */,
+				5E993C1C16FCF92800120305 /* BPTextVisitor.m in Sources */,
+				5E993C2316FD00C200120305 /* BPAccessibilityVisitor.m in Sources */,
+				5E993C2616FD027300120305 /* BPAccessibilityElement.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -366,6 +422,10 @@
 				5E5BC87B16E11F7300165503 /* BPElementTests.mm in Sources */,
 				5E5BC87F16E134C200165503 /* BPDocumentTests.mm in Sources */,
 				5E5BC88216E1448C00165503 /* BPParserTests.m in Sources */,
+				5E3C9F7E16FCCF2A000384CB /* BPElementWalkerTests.mm in Sources */,
+				5E3C9F8416FCD2F7000384CB /* BPWalkEventAccumulator.m in Sources */,
+				5E993C2016FCFB1000120305 /* BPTextVisitorTests.mm in Sources */,
+				5E993C2816FD183C00120305 /* BPAccessibilityVisitorTests.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/platform/ios/Bypass/Bypass.xcodeproj/project.pbxproj
+++ b/platform/ios/Bypass/Bypass.xcodeproj/project.pbxproj
@@ -24,7 +24,6 @@
 		5E5BC87B16E11F7300165503 /* BPElementTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5E5BC87A16E11F7300165503 /* BPElementTests.mm */; };
 		5E5BC87F16E134C200165503 /* BPDocumentTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5E5BC87E16E134C200165503 /* BPDocumentTests.mm */; };
 		5E5BC88216E1448C00165503 /* BPParserTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E5BC88116E1448C00165503 /* BPParserTests.m */; };
-		5E5BC88716E15C5800165503 /* BPAttributedStringConverter.m in Sources */ = {isa = PBXBuildFile; fileRef = 5E5BC88616E15C5800165503 /* BPAttributedStringConverter.m */; };
 		5E5BC89116E79B2E00165503 /* array.c in Sources */ = {isa = PBXBuildFile; fileRef = 5E5BC88B16E79B2E00165503 /* array.c */; };
 		5E5BC89216E79B2E00165503 /* buffer.c in Sources */ = {isa = PBXBuildFile; fileRef = 5E5BC88D16E79B2E00165503 /* buffer.c */; };
 		5E5BC89316E79B2E00165503 /* markdown.c in Sources */ = {isa = PBXBuildFile; fileRef = 5E5BC88F16E79B2E00165503 /* markdown.c */; };
@@ -39,6 +38,7 @@
 		5E993C2816FD183C00120305 /* BPAccessibilityVisitorTests.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5E993C2716FD183C00120305 /* BPAccessibilityVisitorTests.mm */; };
 		5E993C2916FD197300120305 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5E5BC84F16E005E700165503 /* UIKit.framework */; };
 		6BE4F72716F0E9D100670C16 /* BPMarkdownPageView.m in Sources */ = {isa = PBXBuildFile; fileRef = 6BE4F72616F0E9D100670C16 /* BPMarkdownPageView.m */; };
+		C85A593F1738523600B9C2F2 /* BPAttributedTextVisitor.m in Sources */ = {isa = PBXBuildFile; fileRef = C85A593E1738523600B9C2F2 /* BPAttributedTextVisitor.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -92,8 +92,6 @@
 		5E5BC87D16E12E3100165503 /* BPDocumentPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPDocumentPrivate.h; sourceTree = "<group>"; };
 		5E5BC87E16E134C200165503 /* BPDocumentTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BPDocumentTests.mm; sourceTree = "<group>"; };
 		5E5BC88116E1448C00165503 /* BPParserTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPParserTests.m; sourceTree = "<group>"; };
-		5E5BC88516E15C5800165503 /* BPAttributedStringConverter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPAttributedStringConverter.h; sourceTree = "<group>"; };
-		5E5BC88616E15C5800165503 /* BPAttributedStringConverter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPAttributedStringConverter.m; sourceTree = "<group>"; };
 		5E5BC88B16E79B2E00165503 /* array.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = array.c; path = ../../../../dep/libsoldout/array.c; sourceTree = "<group>"; };
 		5E5BC88C16E79B2E00165503 /* array.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = array.h; path = ../../../../dep/libsoldout/array.h; sourceTree = "<group>"; };
 		5E5BC88D16E79B2E00165503 /* buffer.c */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.c; name = buffer.c; path = ../../../../dep/libsoldout/buffer.c; sourceTree = "<group>"; };
@@ -117,6 +115,8 @@
 		5E993C2716FD183C00120305 /* BPAccessibilityVisitorTests.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = BPAccessibilityVisitorTests.mm; sourceTree = "<group>"; };
 		6BE4F72516F0E9D100670C16 /* BPMarkdownPageView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPMarkdownPageView.h; sourceTree = "<group>"; };
 		6BE4F72616F0E9D100670C16 /* BPMarkdownPageView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPMarkdownPageView.m; sourceTree = "<group>"; };
+		C85A593D1738521800B9C2F2 /* BPAttributedTextVisitor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BPAttributedTextVisitor.h; sourceTree = "<group>"; };
+		C85A593E1738523600B9C2F2 /* BPAttributedTextVisitor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BPAttributedTextVisitor.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -256,6 +256,8 @@
 				5E993C2216FD00C200120305 /* BPAccessibilityVisitor.m */,
 				5E993C1A16FCF92800120305 /* BPTextVisitor.h */,
 				5E993C1B16FCF92800120305 /* BPTextVisitor.m */,
+				C85A593D1738521800B9C2F2 /* BPAttributedTextVisitor.h */,
+				C85A593E1738523600B9C2F2 /* BPAttributedTextVisitor.m */,
 			);
 			name = Visitors;
 			sourceTree = "<group>";
@@ -273,8 +275,6 @@
 			isa = PBXGroup;
 			children = (
 				5E993C1D16FCF9CA00120305 /* Visitors */,
-				5E5BC88516E15C5800165503 /* BPAttributedStringConverter.h */,
-				5E5BC88616E15C5800165503 /* BPAttributedStringConverter.m */,
 				5E5BC87116E0083D00165503 /* BPDocument.h */,
 				5E5BC87216E0083D00165503 /* BPDocument.mm */,
 				5E5BC87D16E12E3100165503 /* BPDocumentPrivate.h */,
@@ -399,7 +399,6 @@
 				5E5BC85316E0066E00165503 /* BPParser.mm in Sources */,
 				5E5BC87316E0083D00165503 /* BPDocument.mm in Sources */,
 				5E5BC87616E0085000165503 /* BPElement.mm in Sources */,
-				5E5BC88716E15C5800165503 /* BPAttributedStringConverter.m in Sources */,
 				5E5BC89116E79B2E00165503 /* array.c in Sources */,
 				5E5BC89216E79B2E00165503 /* buffer.c in Sources */,
 				5E5BC89316E79B2E00165503 /* markdown.c in Sources */,
@@ -412,6 +411,7 @@
 				5E993C1C16FCF92800120305 /* BPTextVisitor.m in Sources */,
 				5E993C2316FD00C200120305 /* BPAccessibilityVisitor.m in Sources */,
 				5E993C2616FD027300120305 /* BPAccessibilityElement.m in Sources */,
+				C85A593F1738523600B9C2F2 /* BPAttributedTextVisitor.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/platform/ios/Bypass/Bypass/BPAccessibilityElement.h
+++ b/platform/ios/Bypass/Bypass/BPAccessibilityElement.h
@@ -1,0 +1,25 @@
+//
+//  BPAccessibilityElement.h
+//  Bypass
+//
+//  Created by Damian Carrillo on 3/22/13.
+//  Copyright 2013 Uncodin, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface BPAccessibilityElement : UIAccessibilityElement
+@property (assign, nonatomic) NSRange textRange;
+@end

--- a/platform/ios/Bypass/Bypass/BPAccessibilityElement.m
+++ b/platform/ios/Bypass/Bypass/BPAccessibilityElement.m
@@ -1,0 +1,30 @@
+//
+//  BPAccessibilityElement.m
+//  Bypass
+//
+//  Created by Damian Carrillo on 3/22/13.
+//  Copyright 2013 Uncodin, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "BPAccessibilityElement.h"
+
+@implementation BPAccessibilityElement
+
+- (BOOL)isAccessibilityElement
+{
+    return YES;
+}
+
+@end

--- a/platform/ios/Bypass/Bypass/BPAccessibilityVisitor.h
+++ b/platform/ios/Bypass/Bypass/BPAccessibilityVisitor.h
@@ -28,7 +28,7 @@
  */
 - (id)initWithAccessibilityContainer:(id)container;
 
-- (NSArray *)accessibilityElements;
+- (NSArray *)accessibleElements;
 - (NSArray *)linkIndices;
 
 @end

--- a/platform/ios/Bypass/Bypass/BPAccessibilityVisitor.h
+++ b/platform/ios/Bypass/Bypass/BPAccessibilityVisitor.h
@@ -1,0 +1,34 @@
+//
+//  BPAccessibilityVisitor.h
+//  Bypass
+//
+//  Created by Damian Carrillo on 3/22/13.
+//  Copyright 2013 Uncodin, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import "BPElementWalker.h"
+
+@interface BPAccessibilityVisitor : NSObject<BPElementVisitor>
+
+/*!
+ * \brief Creates and initializes an accessibility visitor to represent an item in the specified container.
+ */
+- (id)initWithAccessibilityContainer:(id)container;
+
+- (NSArray *)accessibilityElements;
+- (NSArray *)linkIndices;
+
+@end

--- a/platform/ios/Bypass/Bypass/BPAccessibilityVisitor.m
+++ b/platform/ios/Bypass/Bypass/BPAccessibilityVisitor.m
@@ -35,7 +35,9 @@
 
 - (id)init
 {
-    return [self initWithAccessibilityContainer:nil];
+    [NSException raise:@"Use initWithAccessibilityContainer:" format:@"Use initWithAccessibilityContainer:"];
+    
+    return self;
 }
 
 - (id)initWithAccessibilityContainer:(id)accessibilityContainer
@@ -59,7 +61,7 @@
     // do nothing
 }
 
-- (void)elementWalker:(BPElementWalker *)elementWalker
+- (int)elementWalker:(BPElementWalker *)elementWalker
       didVisitElement:(BPElement *)element
         withTextRange:(NSRange)textRange
 {
@@ -85,6 +87,8 @@
     [_accumulatedAccessibilityElements addObject:accessibilityElement];
     
     _elementIndex++;
+    
+    return 0;
 }
 
 - (NSArray *)accessibilityElements

--- a/platform/ios/Bypass/Bypass/BPAccessibilityVisitor.m
+++ b/platform/ios/Bypass/Bypass/BPAccessibilityVisitor.m
@@ -1,0 +1,108 @@
+//
+//  BPAccessibilityVisitor.m
+//  Bypass
+//
+//  Created by Damian Carrillo on 3/22/13.
+//  Copyright 2013 Uncodin, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <UIKit/UIKit.h>
+#import "BPAccessibilityElement.h"
+#import "BPAccessibilityVisitor.h"
+#import "BPElement.h"
+
+@implementation BPAccessibilityVisitor
+{
+    NSUInteger      _elementIndex;
+    id              _accessibilityContainer;
+    NSMutableArray *_accumulatedAccessibilityElements;
+    NSArray        *_accessibilityElements;
+    NSMutableArray *_accumulatedLinkIndices;
+    NSArray        *_linkIndices;
+}
+
+- (id)init
+{
+    return [self initWithAccessibilityContainer:nil];
+}
+
+- (id)initWithAccessibilityContainer:(id)accessibilityContainer
+{
+    self = [super init];
+    
+    if (self != nil) {
+        _elementIndex = 0;
+        _accessibilityContainer = accessibilityContainer;
+        _accumulatedAccessibilityElements = [[NSMutableArray alloc] init];
+        _accumulatedLinkIndices = [[NSMutableArray alloc] init];
+    }
+    
+    return self;
+}
+
+- (void)elementWalker:(BPElementWalker *)elementWalker
+     willVisitElement:(BPElement *)element
+        withTextRange:(NSRange)textRange
+{
+    // do nothing
+}
+
+- (void)elementWalker:(BPElementWalker *)elementWalker
+      didVisitElement:(BPElement *)element
+        withTextRange:(NSRange)textRange
+{
+    BPAccessibilityElement *accessibilityElement =
+        [[BPAccessibilityElement alloc] initWithAccessibilityContainer:_accessibilityContainer];
+    
+    [accessibilityElement setTextRange:textRange];
+    [accessibilityElement setAccessibilityValue:[element text]];
+    [accessibilityElement setAccessibilityLabel:[element text]];
+
+    // Determine appropriate accessibility traits based on the element type
+    
+    UIAccessibilityTraits accessibilityTraits;
+    
+    if ([element elementType] == BPLink) {
+        accessibilityTraits = UIAccessibilityTraitStaticText | UIAccessibilityTraitLink;
+        [_accumulatedLinkIndices addObject:@(_elementIndex)];
+    } else {
+        accessibilityTraits = UIAccessibilityTraitStaticText;
+    }
+    
+    [accessibilityElement setAccessibilityTraits:accessibilityTraits];
+    [_accumulatedAccessibilityElements addObject:accessibilityElement];
+    
+    _elementIndex++;
+}
+
+- (NSArray *)accessibilityElements
+{
+    if (_accessibilityElements == nil) {
+        _accessibilityElements = [NSArray arrayWithArray:_accumulatedAccessibilityElements];
+    }
+    
+    return _accessibilityElements;
+}
+
+- (NSArray *)linkIndices
+{
+    if (_linkIndices == nil) {
+        _linkIndices = [NSArray arrayWithArray:_accumulatedLinkIndices];
+    }
+    
+    return _linkIndices;
+}
+
+@end

--- a/platform/ios/Bypass/Bypass/BPAccessibilityVisitor.m
+++ b/platform/ios/Bypass/Bypass/BPAccessibilityVisitor.m
@@ -28,7 +28,7 @@
     NSUInteger      _elementIndex;
     id              _accessibilityContainer;
     NSMutableArray *_accumulatedAccessibilityElements;
-    NSArray        *_accessibilityElements;
+    NSArray        *_accessibleElements;
     NSMutableArray *_accumulatedLinkIndices;
     NSArray        *_linkIndices;
 }
@@ -65,6 +65,11 @@
       didVisitElement:(BPElement *)element
         withTextRange:(NSRange)textRange
 {
+    if ([element text] == nil) {
+        // Element is structural and won't need an accessibility element
+        return 0;
+    }
+        
     BPAccessibilityElement *accessibilityElement =
         [[BPAccessibilityElement alloc] initWithAccessibilityContainer:_accessibilityContainer];
     
@@ -74,13 +79,16 @@
 
     // Determine appropriate accessibility traits based on the element type
     
-    UIAccessibilityTraits accessibilityTraits;
+    UIAccessibilityTraits accessibilityTraits = UIAccessibilityTraitStaticText;
     
     if ([element elementType] == BPLink) {
-        accessibilityTraits = UIAccessibilityTraitStaticText | UIAccessibilityTraitLink;
+        accessibilityTraits |= UIAccessibilityTraitLink;
         [_accumulatedLinkIndices addObject:@(_elementIndex)];
-    } else {
-        accessibilityTraits = UIAccessibilityTraitStaticText;
+    }
+    
+    if ([[element parentElement] elementType] == BPHeader) {
+        // Header text has a parent element of type BPHeader
+        accessibilityTraits |= UIAccessibilityTraitHeader;
     }
     
     [accessibilityElement setAccessibilityTraits:accessibilityTraits];
@@ -91,13 +99,13 @@
     return 0;
 }
 
-- (NSArray *)accessibilityElements
+- (NSArray *)accessibleElements
 {
-    if (_accessibilityElements == nil) {
-        _accessibilityElements = [NSArray arrayWithArray:_accumulatedAccessibilityElements];
+    if (_accessibleElements == nil) {
+        _accessibleElements = [NSArray arrayWithArray:_accumulatedAccessibilityElements];
     }
     
-    return _accessibilityElements;
+    return _accessibleElements;
 }
 
 - (NSArray *)linkIndices

--- a/platform/ios/Bypass/Bypass/BPAttributedTextVisitor.h
+++ b/platform/ios/Bypass/Bypass/BPAttributedTextVisitor.h
@@ -1,8 +1,8 @@
 //
-//  BPAttributedStringRenderer.h
+//  BPAttributedTextVisitor.h
 //  Bypass
 //
-//  Created by Damian Carrillo on 3/1/13.
+//  Created by Damian Carrillo on 3/22/13.
 //  Copyright 2013 Uncodin, Inc.
 //
 //  Licensed under the Apache License, Version 2.0 (the "License");
@@ -18,16 +18,16 @@
 //  limitations under the License.
 //
 
+#import <Foundation/Foundation.h>
+#import <CoreText/CoreText.h>
 #import <UIKit/UIKit.h>
-#import "BPDocument.h"
+#import "Bypass.h"
+#import "BPElementWalker.h"
 
-OBJC_EXPORT NSString *const BPLinkStyleAttributeName;
+OBJC_EXPORT NSString* const BPLinkStyleAttributeName;
 
-/*!
- \brief Renders a Bypass Document to an `NSAttributedString`.
- */
-@interface BPAttributedStringConverter : NSObject
+@interface BPAttributedTextVisitor : NSObject <BPElementVisitor>
 
-- (NSAttributedString *)convertDocument:(BPDocument *)document;
+@property NSMutableAttributedString*  attributedText;
 
 @end

--- a/platform/ios/Bypass/Bypass/BPElement.mm
+++ b/platform/ios/Bypass/Bypass/BPElement.mm
@@ -53,7 +53,7 @@ const BPElementType BPText           = Bypass::TEXT;
 
 @implementation BPElement
 {
-           Bypass::Element _element;
+           Bypass::Element  _element;
            NSString        *_text;
            NSDictionary    *_attributes;
     __weak BPElement       *_parentElement;

--- a/platform/ios/Bypass/Bypass/BPElementWalker.h
+++ b/platform/ios/Bypass/Bypass/BPElementWalker.h
@@ -37,7 +37,9 @@
 - (void)elementWalker:(BPElementWalker *)elementWalker
      willVisitElement:(BPElement *)element
         withTextRange:(NSRange)textRange;
-- (void)elementWalker:(BPElementWalker *)elementWalker
+
+// Returns the number of characters added to the element's text. If characters were removed, the return value should be negative.
+- (int)elementWalker:(BPElementWalker *)elementWalker
       didVisitElement:(BPElement *)element
         withTextRange:(NSRange)textRange;
 

--- a/platform/ios/Bypass/Bypass/BPElementWalker.h
+++ b/platform/ios/Bypass/Bypass/BPElementWalker.h
@@ -1,0 +1,44 @@
+//
+//  BPElementWalker.h
+//  Bypass
+//
+//  Created by Damian Carrillo on 3/22/13.
+//  Copyright 2013 Uncodin, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+
+@class    BPElement;
+@class    BPDocument;
+@protocol BPElementVisitor;
+
+@interface BPElementWalker : NSObject
+
+- (void)addElementVisitor:(id<BPElementVisitor>)elementVisitor;
+- (void)walkDocument:(BPDocument *)document;
+
+@end
+
+@protocol BPElementVisitor <NSObject>
+@required
+
+- (void)elementWalker:(BPElementWalker *)elementWalker
+     willVisitElement:(BPElement *)element
+        withTextRange:(NSRange)textRange;
+- (void)elementWalker:(BPElementWalker *)elementWalker
+      didVisitElement:(BPElement *)element
+        withTextRange:(NSRange)textRange;
+
+@end

--- a/platform/ios/Bypass/Bypass/BPElementWalker.m
+++ b/platform/ios/Bypass/Bypass/BPElementWalker.m
@@ -1,0 +1,82 @@
+//
+//  BPElementWalker.m
+//  Bypass
+//
+//  Created by Damian Carrillo on 3/22/13.
+//  Copyright 2013 Uncodin, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "BPDocument.h"
+#import "BPElementWalker.h"
+
+@implementation BPElementWalker
+{
+    NSMutableArray *_elementVisitors;
+    NSUInteger      _location;
+}
+
+- (id)init
+{
+    self = [super init];
+    
+    if (self != nil) {
+        _elementVisitors = [[NSMutableArray alloc] init];
+    }
+    
+    return self;
+}
+
+- (void)addElementVisitor:(id<BPElementVisitor>)elementVisitor
+{
+    [_elementVisitors addObject:elementVisitor];
+}
+
+- (void)walkDocument:(BPDocument *)document
+{
+    _location = 0;
+    
+    for (BPElement *element in [document elements]) {
+        [self walkSubtreeWithRootElement:element];
+    }
+}
+
+- (void)walkSubtreeWithRootElement:(BPElement *)rootElement
+{
+    NSRange textRange;
+    textRange.location = _location;
+    textRange.length = 0U;
+
+    for (id<BPElementVisitor> elementVisitor in _elementVisitors) {
+        [elementVisitor elementWalker:self willVisitElement:rootElement withTextRange:textRange];
+    }
+    
+    for (BPElement *element in [rootElement childElements]) {
+        for (id<BPElementVisitor> elementVisitor in _elementVisitors) {
+            [self walkSubtreeWithRootElement:element];
+            textRange.length = _location - textRange.location;
+        }
+        
+        _location += [[element text] length];
+    }
+    
+    _location += [[rootElement text] length];
+    textRange.length = _location - textRange.location;
+    
+    for (id<BPElementVisitor> elementVisitor in _elementVisitors) {
+        [elementVisitor elementWalker:self didVisitElement:rootElement withTextRange:textRange];
+    }
+}
+
+@end

--- a/platform/ios/Bypass/Bypass/BPElementWalker.m
+++ b/platform/ios/Bypass/Bypass/BPElementWalker.m
@@ -56,26 +56,24 @@
 {
     NSRange textRange;
     textRange.location = _location;
-    textRange.length = 0U;
-
+    
+    // Process child elements first
+    for (BPElement *element in [rootElement childElements]) {
+        [self walkSubtreeWithRootElement:element];
+    }
+    
+    // Set effective range of this element
+    _location += [[rootElement text] length];
+    textRange.length = _location - textRange.location;
+    
+    // Prepare to visit element
     for (id<BPElementVisitor> elementVisitor in _elementVisitors) {
         [elementVisitor elementWalker:self willVisitElement:rootElement withTextRange:textRange];
     }
     
-    for (BPElement *element in [rootElement childElements]) {
-        for (id<BPElementVisitor> elementVisitor in _elementVisitors) {
-            [self walkSubtreeWithRootElement:element];
-            textRange.length = _location - textRange.location;
-        }
-        
-        _location += [[element text] length];
-    }
-    
-    _location += [[rootElement text] length];
-    textRange.length = _location - textRange.location;
-    
+    // Visit element
     for (id<BPElementVisitor> elementVisitor in _elementVisitors) {
-        [elementVisitor elementWalker:self didVisitElement:rootElement withTextRange:textRange];
+        _location += [elementVisitor elementWalker:self didVisitElement:rootElement withTextRange:textRange];
     }
 }
 

--- a/platform/ios/Bypass/Bypass/BPMarkdownPageView.m
+++ b/platform/ios/Bypass/Bypass/BPMarkdownPageView.m
@@ -18,7 +18,7 @@
 //  limitations under the License.
 //
 
-#import "BPAttributedStringConverter.h"
+#import "BPAttributedTextVisitor.h"
 #import "BPDocument.h"
 #import "BPMarkdownPageView.h"
 

--- a/platform/ios/Bypass/Bypass/BPMarkdownView.m
+++ b/platform/ios/Bypass/Bypass/BPMarkdownView.m
@@ -50,17 +50,25 @@ static const NSTimeInterval kReorientationDuration = 0.3;
  *
  */
 static CFArrayRef
-BPCreatePageFrames(BPDocument *document, CGSize pageSize, CGSize *suggestedContentSizeOut) {
-    BPAttributedStringConverter *converter = [[BPAttributedStringConverter alloc] init];
+BPCreatePageFrames(BPDocument *document,
+                   BPAttributedStringConverter *converter,
+                   CGSize pageSize,
+                   CGSize *suggestedContentSizeOut,
+                   NSAttributedString **attributedTextOut) {
+    NSAttributedString *attributedText = [converter convertDocument:document];
     
-    CFAttributedStringRef attributedText;
-    attributedText = (__bridge CFAttributedStringRef) [converter convertDocument:document];
+    if (attributedTextOut != nil) {
+        *attributedTextOut = [converter convertDocument:document];
+    }
     
-    CFIndex len = CFAttributedStringGetLength(attributedText);
+    CFAttributedStringRef attrText;
+    attrText = (__bridge CFAttributedStringRef) attributedText;
+    
+    CFIndex len = CFAttributedStringGetLength(attrText);
     CFMutableAttributedStringRef mutableAttributedText;
     mutableAttributedText = CFAttributedStringCreateMutableCopy(kCFAllocatorDefault,
                                                                 len,
-                                                                attributedText);
+                                                                attrText);
     
     CFMutableArrayRef frames = CFArrayCreateMutable(kCFAllocatorDefault,
                                                     0,
@@ -106,11 +114,12 @@ BPCreatePageFrames(BPDocument *document, CGSize pageSize, CGSize *suggestedConte
 
 @implementation BPMarkdownView
 {
-    BPParser       *_parser;
-    BPDocument     *_document;
-    NSMutableArray *_pageViews;
-    NSArray        *_previousPageViews;
-    CGRect         _previousFrame;
+    BPParser           *_parser;
+    BPDocument         *_document;
+    NSMutableArray     *_pageViews;
+    NSArray            *_previousPageViews;
+    CGRect              _previousFrame;
+    NSAttributedString *_attributedText;
 }
 
 - (id)initWithFrame:(CGRect)frame
@@ -229,8 +238,14 @@ BPCreatePageFrames(BPDocument *document, CGSize pageSize, CGSize *suggestedConte
         CGRect pageRect = CGRectZero;
         pageRect.size = pageSize;
         
+        BPAttributedStringConverter *converter = [[BPAttributedStringConverter alloc] init];
+        
+        NSAttributedString *attributedText;
         CGSize contentSize;
-        CFArrayRef pageFrames = BPCreatePageFrames(_document, pageSize, &contentSize);
+        
+        CFArrayRef pageFrames = BPCreatePageFrames(_document, converter, pageSize, &contentSize, &attributedText);
+        
+        _attributedText = attributedText;
         
         if ([self isAsynchronous]) {
             dispatch_sync(dispatch_get_main_queue(), ^{
@@ -334,6 +349,23 @@ BPCreatePageFrames(BPDocument *document, CGSize pageSize, CGSize *suggestedConte
 - (void)markdownPageView:(BPMarkdownPageView *)markdownView didHaveLinkTapped:(NSString *)link
 {
     [[self linkDelegate] markdownView:self didHaveLinkTapped:link];
+}
+
+#pragma mark UIAccessibility
+
+- (BOOL)isAccessibilityElement
+{
+    return YES;
+}
+
+- (UIAccessibilityTraits)accessibilityTraits
+{
+    return UIAccessibilityTraitStaticText;
+}
+
+- (NSString *)accessibilityValue
+{
+    return [_attributedText string];
 }
 
 @end

--- a/platform/ios/Bypass/Bypass/BPTextVisitor.h
+++ b/platform/ios/Bypass/Bypass/BPTextVisitor.h
@@ -1,0 +1,28 @@
+//
+//  BPTextVisitor.h
+//  Bypass
+//
+//  Created by Damian Carrillo on 3/22/13.
+//  Copyright 2013 Uncodin, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import "BPElementWalker.h"
+
+@interface BPTextVisitor : NSObject <BPElementVisitor>
+
+- (NSString *)text;
+
+@end

--- a/platform/ios/Bypass/Bypass/BPTextVisitor.m
+++ b/platform/ios/Bypass/Bypass/BPTextVisitor.m
@@ -1,0 +1,65 @@
+//
+//  BPTextVisitor.m
+//  Bypass
+//
+//  Created by Damian Carrillo on 3/22/13.
+//  Copyright 2013 Uncodin, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "BPTextVisitor.h"
+#import "BPElement.h"
+
+@implementation BPTextVisitor
+{
+    NSMutableString *_accumulatedText;
+    NSString        *_text;
+}
+
+- (id)init
+{
+    self = [super init];
+    
+    if (self != nil) {
+        _accumulatedText = [[NSMutableString alloc] init];
+        _text = nil;
+    }
+    
+    return self;
+}
+
+- (void)elementWalker:(BPElementWalker *)elementWalker
+     willVisitElement:(BPElement *)element
+        withTextRange:(NSRange)textRange
+{
+    // do nothing
+}
+
+- (void)elementWalker:(BPElementWalker *)elementWalker
+      didVisitElement:(BPElement *)element
+        withTextRange:(NSRange)textRange
+{
+    [_accumulatedText appendString:[element text]];
+}
+
+- (NSString *)text
+{
+    if (_text == nil) {
+        _text = [NSString stringWithString:_accumulatedText];
+    }
+    
+    return _text;
+}
+
+@end

--- a/platform/ios/Bypass/Bypass/BPTextVisitor.m
+++ b/platform/ios/Bypass/Bypass/BPTextVisitor.m
@@ -46,11 +46,13 @@
     // do nothing
 }
 
-- (void)elementWalker:(BPElementWalker *)elementWalker
+- (int)elementWalker:(BPElementWalker *)elementWalker
       didVisitElement:(BPElement *)element
         withTextRange:(NSRange)textRange
 {
     [_accumulatedText appendString:[element text]];
+    
+    return 0;
 }
 
 - (NSString *)text

--- a/platform/ios/Bypass/Bypass/Bypass.h
+++ b/platform/ios/Bypass/Bypass/Bypass.h
@@ -18,8 +18,8 @@
 //  limitations under the License.
 //
 
-#import "BPAttributedStringConverter.h"
 #import "BPElement.h"
 #import "BPDocument.h"
 #import "BPMarkdownView.h"
 #import "BPParser.h"
+#import "BPAttributedTextVisitor.h"

--- a/platform/ios/Bypass/BypassTests/BPAccessibilityVisitorTests.mm
+++ b/platform/ios/Bypass/BypassTests/BPAccessibilityVisitorTests.mm
@@ -36,7 +36,7 @@
 {
     using namespace Bypass;
     
-    _visitor = [[BPAccessibilityVisitor alloc] init];
+    _visitor = [[BPAccessibilityVisitor alloc] initWithAccessibilityContainer:self];
     
     Element e0;
     e0.setType(TEXT);

--- a/platform/ios/Bypass/BypassTests/BPAccessibilityVisitorTests.mm
+++ b/platform/ios/Bypass/BypassTests/BPAccessibilityVisitorTests.mm
@@ -1,0 +1,82 @@
+//
+//  BPAccessibilityVisitorTests.m
+//  Bypass
+//
+//  Created by Damian Carrillo on 3/22/13.
+//  Copyright 2013 Uncodin, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <UIKit/UIKit.h>
+#import <SenTestingKit/SenTestingKit.h>
+#import "BPElementPrivate.h"
+#import "BPAccessibilityVisitor.h"
+
+@interface BPAccessibilityVisitorTests : SenTestCase
+@end
+
+@implementation BPAccessibilityVisitorTests
+{
+    BPAccessibilityVisitor *_visitor;
+    NSArray                *_elements;
+}
+
+- (void)setUp
+{
+    using namespace Bypass;
+    
+    _visitor = [[BPAccessibilityVisitor alloc] init];
+    
+    Element e0;
+    e0.setType(TEXT);
+    e0.setText("one ");
+    BPElement *ee0 = [[BPElement alloc] initWithElement:e0];
+    
+    Element e1;
+    e1.setType(LINK);
+    e1.setText("two");
+    BPElement *ee1 = [[BPElement alloc] initWithElement:e1];
+    
+    Element e2;
+    e2.setType(TEXT);
+    e2.setText(" three");
+    BPElement *ee2 = [[BPElement alloc] initWithElement:e2];
+    
+    _elements = @[ee0, ee1, ee2];
+}
+
+- (void)tearDown
+{
+    _visitor = nil;
+}
+
+- (void)testDidVisitElement {
+    for (BPElement *element in _elements) {
+        NSRange range;
+        range.location = 0;
+        range.length = 0;
+        
+        [_visitor elementWalker:nil willVisitElement:element withTextRange:range];
+        [_visitor elementWalker:nil didVisitElement:element withTextRange:range];
+    }
+    
+    STAssertEquals([[_visitor accessibilityElements] count], 3U,
+                   @"Expected 3 accessibility elements");
+    STAssertEquals([[_visitor linkIndices] count], 1U,
+                   @"Expected 1 link index");
+    STAssertEquals([[_visitor linkIndices][0] unsignedIntegerValue], 1U,
+                   @"Expected link index to point to element 1");
+}
+
+@end

--- a/platform/ios/Bypass/BypassTests/BPDocumentTests.mm
+++ b/platform/ios/Bypass/BypassTests/BPDocumentTests.mm
@@ -1,3 +1,23 @@
+//
+//  BPDocumentTests.m
+//  Bypass
+//
+//  Created by Damian Carrillo on 3/22/13.
+//  Copyright 2013 Uncodin, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
 #import <SenTestingKit/SenTestingKit.h>
 #import "BPDocumentPrivate.h"
 

--- a/platform/ios/Bypass/BypassTests/BPElementTests.mm
+++ b/platform/ios/Bypass/BypassTests/BPElementTests.mm
@@ -1,3 +1,23 @@
+//
+//  BPElementTests.m
+//  Bypass
+//
+//  Created by Damian Carrillo on 3/22/13.
+//  Copyright 2013 Uncodin, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
 #import <SenTestingKit/SenTestingKit.h>
 #import "BPElementPrivate.h"
 

--- a/platform/ios/Bypass/BypassTests/BPElementWalkerTests.mm
+++ b/platform/ios/Bypass/BypassTests/BPElementWalkerTests.mm
@@ -1,0 +1,166 @@
+//
+//  BPElementWalkerTests.m
+//  Bypass
+//
+//  Created by Damian Carrillo on 3/22/13.
+//  Copyright 2013 Uncodin, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+#import "BPElementWalker.h"
+#import "BPDocumentPrivate.h"
+#import "BPElementPrivate.h"
+#import "BPWalkEventAccumulator.h"
+
+@interface BPElementWalkerTests : SenTestCase
+@end
+
+@implementation BPElementWalkerTests
+{
+    BPDocument      *_document;
+    BPElementWalker *_elementWalker;
+}
+
+- (void)setUp
+{
+    _elementWalker = [[BPElementWalker alloc] init];
+    
+    using namespace Bypass;
+    
+    Document d;
+    
+    Element e0;
+    e0.setType(TEXT);
+    e0.setText("one ");
+    d.append(e0);
+    
+    Element e1;
+    e1.setType(DOUBLE_EMPHASIS);
+    e1.setText("two");
+    d.append(e1);
+    
+    Element e2;
+    e2.setType(TEXT);
+    e2.setText(" three");
+    d.append(e2);
+    
+    _document = [[BPDocument alloc] initWithDocument:d];
+    
+    STAssertEquals([[_document elements] count], 3U, @"Expected document to have 3 child elements");
+}
+
+- (void)tearDown
+{
+    _document = nil;
+    _elementWalker = nil;
+}
+
+- (void)testWalkDocument
+{
+    BPWalkEventAccumulator *walkEventAccumulator = [[BPWalkEventAccumulator alloc] init];
+    [_elementWalker addElementVisitor:walkEventAccumulator];
+    [_elementWalker walkDocument:_document];
+    
+    NSArray *events = [walkEventAccumulator accumulatedEvents];
+    
+    STAssertEquals([events count], 6U, @"Expected 6 acumulated events");
+    
+    // Events accumulated for the first element
+    
+    /* Identity Checks */ {
+        STAssertEquals([events[0][BYPASS_ELEMENT] elementType], BPText,
+                       @"Expected a text element");
+        STAssertEquals([events[1][BYPASS_ELEMENT] elementType], BPText,
+                       @"Expected a text element");
+        
+        STAssertEquals([events[0][BYPASS_EVENT_TYPE] unsignedIntegerValue], BPEventTypeBefore,
+                       @"Expected a 'before' event");
+        STAssertEquals([events[1][BYPASS_EVENT_TYPE] unsignedIntegerValue], BPEventTypeAfter,
+                       @"Expected an 'after' event");
+    }
+
+    /* Range Checks */ {
+        STAssertEquals([events[0][BYPASS_RANGE] rangeValue].location, 0U,
+                       @"Expected location 0");
+        STAssertEquals([events[1][BYPASS_RANGE] rangeValue].location, 0U,
+                       @"Expected location 0");
+        
+        STAssertEquals([events[0][BYPASS_RANGE] rangeValue].length, 0U,
+                       @"Expected length 0");
+        STAssertEquals([events[1][BYPASS_RANGE] rangeValue].length,
+                       [[[_document elements][0] text] length],
+                       @"Expected length to match element 1 text");
+    }
+    
+    // Events accumulated for the second element
+    
+    /* Identity Checks */ {
+        STAssertEquals([events[2][BYPASS_ELEMENT] elementType], BPDoubleEmphasis,
+                       @"Expected a double emphasis element");
+        STAssertEquals([events[3][BYPASS_ELEMENT] elementType], BPDoubleEmphasis,
+                       @"Expected a double emphasis element");
+        
+        STAssertEquals([events[2][BYPASS_EVENT_TYPE] unsignedIntegerValue], BPEventTypeBefore,
+                       @"Expected a 'before' event");
+        STAssertEquals([events[3][BYPASS_EVENT_TYPE] unsignedIntegerValue], BPEventTypeAfter,
+                       @"Expected an 'after' event");
+    }
+    
+    /* Range checks */ {
+        STAssertEquals([events[2][BYPASS_RANGE] rangeValue].location,
+                       [[[_document elements][0] text] length],
+                       @"Expected location 0");
+        STAssertEquals([events[3][BYPASS_RANGE] rangeValue].location,
+                       [[[_document elements][0] text] length],
+                       @"Expected location 0");
+        
+        STAssertEquals([events[2][BYPASS_RANGE] rangeValue].length, 0U,
+                       @"Expected length 0");
+        STAssertEquals([events[3][BYPASS_RANGE] rangeValue].length,
+                       [[[_document elements][1] text] length],
+                       @"Expected length to match element 2 text");
+    }
+    
+    // Events accumulated for the third element
+    
+    /* Identity Checks */ {
+        STAssertEquals([events[4][BYPASS_ELEMENT] elementType], BPText,
+                       @"Expected a text element");
+        STAssertEquals([events[5][BYPASS_ELEMENT] elementType], BPText,
+                       @"Expected a text element");
+        
+        STAssertEquals([events[4][BYPASS_EVENT_TYPE] unsignedIntegerValue], BPEventTypeBefore,
+                       @"Expected a 'before' event");
+        STAssertEquals([events[5][BYPASS_EVENT_TYPE] unsignedIntegerValue], BPEventTypeAfter,
+                       @"Expected an 'after' event");
+    }
+    
+    /* Range checks */ {
+        STAssertEquals([events[4][BYPASS_RANGE] rangeValue].location,
+                       [[[_document elements][0] text] length] + [[[_document elements][1] text] length],
+                       @"Expected location 0");
+        STAssertEquals([events[5][BYPASS_RANGE] rangeValue].location,
+                       [[[_document elements][0] text] length] + [[[_document elements][1] text] length],
+                       @"Expected location 0");
+        
+        STAssertEquals([events[4][BYPASS_RANGE] rangeValue].length, 0U,
+                       @"Expected length 0");
+        STAssertEquals([events[5][BYPASS_RANGE] rangeValue].length,
+                       [[[_document elements][2] text] length],
+                       @"Expected length to match element 3 text");
+    }
+}
+
+@end

--- a/platform/ios/Bypass/BypassTests/BPElementWalkerTests.mm
+++ b/platform/ios/Bypass/BypassTests/BPElementWalkerTests.mm
@@ -97,8 +97,8 @@
         STAssertEquals([events[1][BYPASS_RANGE] rangeValue].location, 0U,
                        @"Expected location 0");
         
-        STAssertEquals([events[0][BYPASS_RANGE] rangeValue].length, 0U,
-                       @"Expected length 0");
+        STAssertEquals([events[0][BYPASS_RANGE] rangeValue].length, 4U,
+                       @"Expected length 4");
         STAssertEquals([events[1][BYPASS_RANGE] rangeValue].length,
                        [[[_document elements][0] text] length],
                        @"Expected length to match element 1 text");
@@ -126,8 +126,8 @@
                        [[[_document elements][0] text] length],
                        @"Expected location 0");
         
-        STAssertEquals([events[2][BYPASS_RANGE] rangeValue].length, 0U,
-                       @"Expected length 0");
+        STAssertEquals([events[2][BYPASS_RANGE] rangeValue].length, 3U,
+                       @"Expected length 3");
         STAssertEquals([events[3][BYPASS_RANGE] rangeValue].length,
                        [[[_document elements][1] text] length],
                        @"Expected length to match element 2 text");
@@ -155,8 +155,8 @@
                        [[[_document elements][0] text] length] + [[[_document elements][1] text] length],
                        @"Expected location 0");
         
-        STAssertEquals([events[4][BYPASS_RANGE] rangeValue].length, 0U,
-                       @"Expected length 0");
+        STAssertEquals([events[4][BYPASS_RANGE] rangeValue].length, 6U,
+                       @"Expected length 6");
         STAssertEquals([events[5][BYPASS_RANGE] rangeValue].length,
                        [[[_document elements][2] text] length],
                        @"Expected length to match element 3 text");

--- a/platform/ios/Bypass/BypassTests/BPParserTests.m
+++ b/platform/ios/Bypass/BypassTests/BPParserTests.m
@@ -1,3 +1,23 @@
+//
+//  BPParserTests.m
+//  Bypass
+//
+//  Created by Damian Carrillo on 3/22/13.
+//  Copyright 2013 Uncodin, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
 #import <SenTestingKit/SenTestingKit.h>
 #import "BPParser.h"
 

--- a/platform/ios/Bypass/BypassTests/BPTextVisitorTests.mm
+++ b/platform/ios/Bypass/BypassTests/BPTextVisitorTests.mm
@@ -1,0 +1,76 @@
+//
+//  BPTextVisitorTests.m
+//  Bypass
+//
+//  Created by Damian Carrillo on 3/22/13.
+//  Copyright 2013 Uncodin, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <SenTestingKit/SenTestingKit.h>
+#import "BPElementPrivate.h"
+#import "BPTextVisitor.h"
+
+@interface BPTextVisitorTests : SenTestCase
+@end
+
+@implementation BPTextVisitorTests
+{
+    BPTextVisitor *_visitor;
+    NSArray       *_elements;
+}
+
+- (void)setUp
+{
+    using namespace Bypass;
+    
+    _visitor = [[BPTextVisitor alloc] init];
+    
+    Element e0;
+    e0.setType(TEXT);
+    e0.setText("one ");
+    BPElement *ee0 = [[BPElement alloc] initWithElement:e0];
+    
+    Element e1;
+    e1.setType(DOUBLE_EMPHASIS);
+    e1.setText("two");
+    BPElement *ee1 = [[BPElement alloc] initWithElement:e1];
+    
+    Element e2;
+    e2.setType(TEXT);
+    e2.setText(" three");
+    BPElement *ee2 = [[BPElement alloc] initWithElement:e2];
+    
+    _elements = @[ee0, ee1, ee2];
+}
+
+- (void)tearDown
+{
+    _visitor = nil;
+}
+
+- (void)testDidVisitElement {
+    for (BPElement *element in _elements) {
+        NSRange range;
+        range.location = 0;
+        range.length = 0;
+
+        [_visitor elementWalker:nil willVisitElement:element withTextRange:range];
+        [_visitor elementWalker:nil didVisitElement:element withTextRange:range];
+    }
+    
+    STAssertEqualObjects([_visitor text], @"one two three", @"Expected \"one two three\"");
+}
+
+@end

--- a/platform/ios/Bypass/BypassTests/BPWalkEventAccumulator.h
+++ b/platform/ios/Bypass/BypassTests/BPWalkEventAccumulator.h
@@ -1,0 +1,41 @@
+//
+//  BPWalkEventAccumulator.h
+//  Bypass
+//
+//  Created by Damian Carrillo on 3/22/13.
+//  Copyright 2013 Uncodin, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import <Foundation/Foundation.h>
+#import "BPElementWalker.h"
+
+OBJC_EXPORT NSString *const BYPASS_ELEMENT;
+OBJC_EXPORT NSString *const BYPASS_RANGE;
+OBJC_EXPORT NSString *const BYPASS_EVENT_TYPE;
+
+NS_ENUM(NSUInteger, BPEventType)
+{
+    BPEventTypeBefore,
+    BPEventTypeAfter
+};
+
+@interface BPWalkEventAccumulator : NSObject <BPElementVisitor>
+
+/*
+ * An array of NSDictionaries.
+ */
+- (NSArray *)accumulatedEvents;
+
+@end

--- a/platform/ios/Bypass/BypassTests/BPWalkEventAccumulator.m
+++ b/platform/ios/Bypass/BypassTests/BPWalkEventAccumulator.m
@@ -51,7 +51,7 @@ NSString *const BYPASS_EVENT_TYPE = @"BYPASS_EVENT_TYPE";
   }];
 }
 
-- (void)elementWalker:(BPElementWalker *)elementWalker
+- (int)elementWalker:(BPElementWalker *)elementWalker
       didVisitElement:(BPElement *)element
         withTextRange:(NSRange)textRange
 {
@@ -60,6 +60,8 @@ NSString *const BYPASS_EVENT_TYPE = @"BYPASS_EVENT_TYPE";
         BYPASS_RANGE: [NSValue valueWithRange:textRange],
         BYPASS_EVENT_TYPE: @(BPEventTypeAfter)
     }];
+    
+    return 0;
 }
 
 - (NSArray *)accumulatedEvents

--- a/platform/ios/Bypass/BypassTests/BPWalkEventAccumulator.m
+++ b/platform/ios/Bypass/BypassTests/BPWalkEventAccumulator.m
@@ -1,0 +1,70 @@
+//
+//  BPWalkEventAccumulator.m
+//  Bypass
+//
+//  Created by Damian Carrillo on 3/22/13.
+//  Copyright 2013 Uncodin, Inc.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#import "BPWalkEventAccumulator.h"
+
+NSString *const BYPASS_ELEMENT    = @"BYPASS_ELEMENT";
+NSString *const BYPASS_RANGE      = @"BYPASS_RANGE";
+NSString *const BYPASS_EVENT_TYPE = @"BYPASS_EVENT_TYPE";
+
+@implementation BPWalkEventAccumulator
+{
+    NSMutableArray *_accumulatedEvents;
+}
+
+- (id)init
+{
+    self = [super init];
+    
+    if (self != nil) {
+        _accumulatedEvents = [[NSMutableArray alloc] init];
+    }
+    
+    return self;
+}
+
+- (void)elementWalker:(BPElementWalker *)elementWalker
+     willVisitElement:(BPElement *)element
+        withTextRange:(NSRange)textRange
+{
+  [_accumulatedEvents addObject:@{
+      BYPASS_ELEMENT: element,
+      BYPASS_RANGE: [NSValue valueWithRange:textRange],
+      BYPASS_EVENT_TYPE: @(BPEventTypeBefore)
+  }];
+}
+
+- (void)elementWalker:(BPElementWalker *)elementWalker
+      didVisitElement:(BPElement *)element
+        withTextRange:(NSRange)textRange
+{
+    [_accumulatedEvents addObject:@{
+        BYPASS_ELEMENT: element,
+        BYPASS_RANGE: [NSValue valueWithRange:textRange],
+        BYPASS_EVENT_TYPE: @(BPEventTypeAfter)
+    }];
+}
+
+- (NSArray *)accumulatedEvents
+{
+    return [NSArray arrayWithArray:_accumulatedEvents];
+}
+
+@end

--- a/platform/ios/BypassSample/BypassSample/BPTextViewController.mm
+++ b/platform/ios/BypassSample/BypassSample/BPTextViewController.mm
@@ -66,8 +66,13 @@
     BPParser *parser = [[BPParser alloc] init];
     BPDocument *document = [parser parse:sample];
     
-    BPAttributedStringConverter *converter = [[BPAttributedStringConverter alloc] init];
-    NSAttributedString *attributedText = [converter convertDocument:document];
+    BPAttributedTextVisitor* textVisitor = [BPAttributedTextVisitor new];
+
+    BPElementWalker* walker = [BPElementWalker new];
+    [walker addElementVisitor:textVisitor];
+    [walker walkDocument:document];
+    
+    NSAttributedString *attributedText = textVisitor.attributedText;
     
     // Warning: The attributed text is being set on a simple UITextView out of convenience. After this has been done,
     //          Bypass' custom text attributes have been stripped. We save a copy to use as a point of reference for

--- a/platform/ios/BypassSample/BypassSample/en.lproj/MainStoryboard.storyboard
+++ b/platform/ios/BypassSample/BypassSample/en.lproj/MainStoryboard.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="2.0" toolsVersion="3084" systemVersion="12D78" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="coK-dy-9r8">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="2.0" toolsVersion="3084" systemVersion="12C60" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" initialViewController="coK-dy-9r8">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="2083"/>
     </dependencies>
@@ -44,7 +44,7 @@
                     </connections>
                 </tapGestureRecognizer>
             </objects>
-            <point key="canvasLocation" x="685" y="-574"/>
+            <point key="canvasLocation" x="589" y="150"/>
         </scene>
         <!--Markdown View Controller - BPMarkdownView-->
         <scene sceneID="kXe-v1-588">
@@ -62,7 +62,7 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="TJz-sc-Buy" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="685" y="110"/>
+            <point key="canvasLocation" x="589" y="-554"/>
         </scene>
         <!--Tab Bar Controller-->
         <scene sceneID="WN2-FR-bhK">
@@ -75,8 +75,8 @@
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                     </tabBar>
                     <connections>
-                        <segue destination="2" kind="relationship" relationship="viewControllers" id="kff-tx-7Qn"/>
                         <segue destination="sdw-IH-RGJ" kind="relationship" relationship="viewControllers" id="tTc-fo-urU"/>
+                        <segue destination="2" kind="relationship" relationship="viewControllers" id="XbW-c4-N8k"/>
                     </connections>
                 </tabBarController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Bt0-3A-Iib" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/platform/ios/BypassSample/BypassSample/sample.markdown
+++ b/platform/ios/BypassSample/BypassSample/sample.markdown
@@ -10,10 +10,9 @@ github page for Bypass [here](https://github.com/Uncodin/bypass).
 	* One
 	* Two
 	* Three
-* One
-	* One
-	* Two
-	* Three
+		* One
+		* Two
+		* Three
 
 ## Code Block Support
 


### PR DESCRIPTION
Markdown rendering now uses `BPAttributedTextVisitor` in conjunction with `BPElementWalker`.

This method of traversing the tree should make it easier to finish implementing proper accessibility support (#111).