### PR TITLE
Boost removal

### DIFF
--- a/platform/ios/Bypass/Bypass/BPAttributedStringConverter.m
+++ b/platform/ios/Bypass/Bypass/BPAttributedStringConverter.m
@@ -92,6 +92,8 @@ NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
         [self renderBoldItalicElement:element toTarget:target];
     } else if (elementType == BPText) {
         [self renderTextElement:element toTarget:target];
+    } else if (elementType == BPStrikethrough) {
+        [self renderStruckthroughElement:element toTarget:target];
     }
     
     // Render children of this particular element recursively
@@ -199,6 +201,17 @@ NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
     [self renderSpanElement:element withFont:[_displaySettings italicFont] toTarget:target];
 }
 
+- (void)renderStruckthroughElement:(BPElement *)element
+                          toTarget:(NSMutableAttributedString *)target
+{
+    NSMutableDictionary *attributes = [NSMutableDictionary dictionary];
+    attributes[NSStrikethroughStyleAttributeName] = @(1);
+    [self renderSpanElement:element
+                   withFont:[_displaySettings defaultFont]
+                 attributes:attributes
+                   toTarget:target];
+}
+
 - (void)renderCodeSpanElement:(BPElement *)element
                      toTarget:(NSMutableAttributedString *)target
 {
@@ -214,7 +227,8 @@ NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
     attributes[BPLinkStyleAttributeName] = element[@"link"];
     [self renderSpanElement:element
                    withFont:[_displaySettings defaultFont]
-                 attributes:attributes toTarget:target];
+                 attributes:attributes
+                   toTarget:target];
 }
 
 - (void)renderLineBreak:(BPElement *)element

--- a/platform/ios/Bypass/Bypass/BPElement.h
+++ b/platform/ios/Bypass/Bypass/BPElement.h
@@ -48,6 +48,7 @@ FOUNDATION_EXPORT const BPElementType BPLink;
 FOUNDATION_EXPORT const BPElementType BPRawHTMLTag;
 FOUNDATION_EXPORT const BPElementType BPTripleEmphasis;
 FOUNDATION_EXPORT const BPElementType BPText;
+FOUNDATION_EXPORT const BPElementType BPStrikethrough;
 
 @interface BPElement : NSObject
 @property (assign, nonatomic, readonly) BPElementType elementType;

--- a/platform/ios/Bypass/Bypass/BPElement.mm
+++ b/platform/ios/Bypass/Bypass/BPElement.mm
@@ -46,6 +46,7 @@ const BPElementType BPLink           = Bypass::LINK;
 const BPElementType BPRawHTMLTag     = Bypass::RAW_HTML_TAG;
 const BPElementType BPTripleEmphasis = Bypass::TRIPLE_EMPHASIS;
 const BPElementType BPText           = Bypass::TEXT;
+const BPElementType BPStrikethrough  = Bypass::STRIKETHROUGH;
 
 @interface BPElement ()
 
@@ -213,6 +214,8 @@ const BPElementType BPText           = Bypass::TEXT;
         elementType = @"BPTripleEmphasis";
     } else if ([self elementType] == BPText) {
         elementType = @"BPText";
+    } else if ([self elementType] == BPStrikethrough) {
+        elementType = @"BPStrikethrough";
     }
     
     NSMutableString *desc = [NSMutableString stringWithString:NSStringFromClass([self class])];

--- a/src/element.cpp
+++ b/src/element.cpp
@@ -152,9 +152,9 @@ namespace Bypass {
 				break;
 			case TEXT:
 				type = "TEXT";
-                break;
-            case STRIKETHROUGH:
-                type = "STRIKETHROUGH";
+				break;
+			case STRIKETHROUGH:
+				type = "STRIKETHROUGH";
 				break;
 		}
 

--- a/src/element.cpp
+++ b/src/element.cpp
@@ -152,6 +152,9 @@ namespace Bypass {
 				break;
 			case TEXT:
 				type = "TEXT";
+                break;
+            case STRIKETHROUGH:
+                type = "STRIKETHROUGH";
 				break;
 		}
 

--- a/src/element.h
+++ b/src/element.h
@@ -53,8 +53,8 @@ namespace Bypass {
 		LINK            = 0x111,
 		RAW_HTML_TAG    = 0x112,
 		TRIPLE_EMPHASIS = 0x113,
-		TEXT            = 0x114
-
+		TEXT            = 0x114,
+        STRIKETHROUGH   = 0x115
 	};
 
 	class Element {

--- a/src/element.h
+++ b/src/element.h
@@ -54,7 +54,7 @@ namespace Bypass {
 		RAW_HTML_TAG    = 0x112,
 		TRIPLE_EMPHASIS = 0x113,
 		TEXT            = 0x114,
-        STRIKETHROUGH   = 0x115
+		STRIKETHROUGH   = 0x115
 	};
 
 	class Element {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -198,7 +198,7 @@ namespace Bypass {
 
 	// Span Element Callbacks
 
-	void Parser::handleSpan(Type type, struct buf *ob, struct buf *text, struct buf *extra, struct buf *extra2) {
+	void Parser::handleSpan(Type type, struct buf *ob, struct buf *text, struct buf *extra, struct buf *extra2, bool output) {
 
 		std::vector<std::string> strs;
 		std::string textString;
@@ -229,10 +229,14 @@ namespace Bypass {
                 }
                 
                 elementSoup.erase(pos);
-                elementSoup[pos] = element;
+                if (output) {
+                    elementSoup[pos] = element;
+                }
             }
 
-			bufputs(ob, textString.c_str());
+            if (output) {
+                bufputs(ob, textString.c_str());
+            }
 		}
 		else {
 			Element element;
@@ -262,20 +266,22 @@ namespace Bypass {
 
 	int Parser::parsedEmphasis(struct buf *ob, struct buf *text, char c) {
         if (c == '~') {
-            handleSpan(STRIKETHROUGH, ob, text);
+            handleSpan(STRIKETHROUGH, ob, text, NULL, NULL, false);
+            return 0;
         } else {
             handleSpan(EMPHASIS, ob, text);
+            return 1;
         }
-		return 1;
 	}
 
 	int Parser::parsedTripleEmphasis(struct buf *ob, struct buf *text, char c) {
 		if (c == '~') {
-            handleSpan(STRIKETHROUGH, ob, text);
+            handleSpan(STRIKETHROUGH, ob, text, NULL, NULL, false);
+            return 0;
         } else {
             handleSpan(TRIPLE_EMPHASIS, ob, text);
+            return 1;
         }
-		return 1;
 	}
 
 	int Parser::parsedLink(struct buf *ob, struct buf *link, struct buf *title, struct buf *content) {

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -67,7 +67,7 @@ struct mkd_renderer mkd_callbacks = {
 
 	/* renderer data */
 	64, // max stack
-	"*_",
+	"*_~",
 	NULL // opaque
 };
 
@@ -252,17 +252,29 @@ namespace Bypass {
 	}
 
 	int Parser::parsedDoubleEmphasis(struct buf *ob, struct buf *text, char c) {
-		handleSpan(DOUBLE_EMPHASIS, ob, text);
+        if (c == '~') {
+            handleSpan(STRIKETHROUGH, ob, text);
+        } else {
+            handleSpan(DOUBLE_EMPHASIS, ob, text);
+        }
 		return 1;
 	}
 
 	int Parser::parsedEmphasis(struct buf *ob, struct buf *text, char c) {
-		handleSpan(EMPHASIS, ob, text);
+        if (c == '~') {
+            handleSpan(STRIKETHROUGH, ob, text);
+        } else {
+            handleSpan(EMPHASIS, ob, text);
+        }
 		return 1;
 	}
 
 	int Parser::parsedTripleEmphasis(struct buf *ob, struct buf *text, char c) {
-		handleSpan(TRIPLE_EMPHASIS, ob, text);
+		if (c == '~') {
+            handleSpan(STRIKETHROUGH, ob, text);
+        } else {
+            handleSpan(TRIPLE_EMPHASIS, ob, text);
+        }
 		return 1;
 	}
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -77,7 +77,7 @@ namespace Bypass {
 		std::map<int, Element> elementSoup;
 		int elementCount;
 		void handleBlock(Type, struct buf *ob, struct buf *text, int extra = -1);
-		void handleSpan(Type, struct buf *ob, struct buf *text, struct buf *extra = NULL, struct buf *extra2 = NULL);
+		void handleSpan(Type, struct buf *ob, struct buf *text, struct buf *extra = NULL, struct buf *extra2 = NULL, bool output = true);
 		void createSpan(const Element&, struct buf *ob);
 		void eraseTrailingControlCharacters(const std::string& controlCharacters);
 	};

--- a/src/parser.h
+++ b/src/parser.h
@@ -24,7 +24,6 @@
 #include <cstdio>
 #include <cstdlib>
 #include <map>
-#include <boost/algorithm/string.hpp>
 
 extern "C" {
 #include "markdown.h"
@@ -45,6 +44,8 @@ namespace Bypass {
 
 		Document parse(const char* markdown);
 		Document parse(const std::string &markdown);
+
+		void split(std::vector<std::string> &tokens, const std::string &text, char sep);
 
 		// Block Element Callbacks
 

--- a/test/parser_tests.cpp
+++ b/test/parser_tests.cpp
@@ -212,6 +212,55 @@ BOOST_FIXTURE_TEST_CASE(parse_multiple_interspersed_triple_emphasis, F) {
 	BOOST_REQUIRE(document[0][2].size() == 0);
 }
 
+// Strikethrough ---------------------------------------------------------------
+
+BOOST_FIXTURE_TEST_CASE(parse_strikethrough_with_simple_example, F) {
+	Document document = parser.parse("~~hello world~~");
+
+	BOOST_REQUIRE(document.size() == 1);
+	BOOST_REQUIRE(document[0].getType() == PARAGRAPH);
+	BOOST_REQUIRE(document[0].getText().length() == 0);
+	BOOST_REQUIRE(document[0].size() == 1);
+	BOOST_REQUIRE(document[0][0].getType() == STRIKETHROUGH);
+	BOOST_REQUIRE(document[0][0].getText() == "hello world");
+	BOOST_REQUIRE(document[0][0].size() == 0);
+}
+
+BOOST_FIXTURE_TEST_CASE(parse_single_interspersed_strikethrough, F) {
+	Document document = parser.parse("one ~~two~~ three");
+
+	BOOST_REQUIRE(document.size() == 1);
+	BOOST_REQUIRE(document[0].getType() == PARAGRAPH);
+	BOOST_REQUIRE(document[0].getText().length() == 0);
+	BOOST_REQUIRE(document[0].size() == 3);
+	BOOST_REQUIRE(document[0][0].getType() == TEXT);
+	BOOST_REQUIRE(document[0][0].getText() == "one ");
+	BOOST_REQUIRE(document[0][0].size() == 0);
+	BOOST_REQUIRE(document[0][1].getType() == STRIKETHROUGH);
+	BOOST_REQUIRE(document[0][1].getText() == "two");
+	BOOST_REQUIRE(document[0][1].size() == 0);
+	BOOST_REQUIRE(document[0][2].getType() == TEXT);
+	BOOST_REQUIRE(document[0][2].getText() == " three");
+	BOOST_REQUIRE(document[0][2].size() == 0);
+}
+
+BOOST_FIXTURE_TEST_CASE(parse_multiple_interspersed_strikethrough, F) {
+	Document document = parser.parse("~~one~~ two ~~three~~");
+
+	BOOST_REQUIRE(document.size() == 1);
+	BOOST_REQUIRE(document[0].getText().length() == 0);
+	BOOST_REQUIRE(document[0].size() == 3);
+	BOOST_REQUIRE(document[0][0].getType() == STRIKETHROUGH);
+	BOOST_REQUIRE(document[0][0].getText() == "one");
+	BOOST_REQUIRE(document[0][0].size() == 0);
+	BOOST_REQUIRE(document[0][1].getType() == TEXT);
+	BOOST_REQUIRE(document[0][1].getText() == " two ");
+	BOOST_REQUIRE(document[0][1].size() == 0);
+	BOOST_REQUIRE(document[0][2].getType() == STRIKETHROUGH);
+	BOOST_REQUIRE(document[0][2].getText() == "three");
+	BOOST_REQUIRE(document[0][2].size() == 0);
+}
+
 // Link ------------------------------------------------------------------------
 
 BOOST_FIXTURE_TEST_CASE(parse_link_with_simple_example, F) {


### PR DESCRIPTION
Removing boost for users of the library. This will ease the burden of integration. Contributors still need to install boost in order to run the core tests.
