### PR TITLE
Fix build issue because target platforms cannot be found

### DIFF
--- a/platform/android/library/jni/Application.mk
+++ b/platform/android/library/jni/Application.mk
@@ -1,2 +1,2 @@
-APP_ABI := all
+APP_ABI := armeabi armeabi-v7a x86 mips
 APP_STL := gnustl_static

--- a/platform/android/pom.xml
+++ b/platform/android/pom.xml
@@ -109,11 +109,11 @@
 				<plugin>
 					<groupId>com.jayway.maven.plugins.android.generation2</groupId>
 					<artifactId>android-maven-plugin</artifactId>
-					<version>3.7.0</version>
+					<version>3.8.2</version>
 
 					<configuration>
 						<sdk>
-							<platform>16</platform>
+							<platform>19</platform>
 						</sdk>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
I had always a NullPointerException during `mvn install`with the older maven plugin version. This issue was gone with the newest maven plugin and the newer android SDK version. Unfortunately, `mvn install`has still failed because the toolchain targets were not found. Therefore, I have specified the platforms in `Application.mk` and it works now.
