### PR TITLE
Fixed flag printing for LIST elements

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -152,8 +152,8 @@ namespace Bypass {
 			block.addAttribute("level", levelStr);
 		}
 		else if (type == LIST) {
-			char flagsStr[2];
-			snprintf(flagsStr, 2, "%d", extra);
+			char flagsStr[3];
+			snprintf(flagsStr, 3, "%d", extra);
 			block.addAttribute("flags", flagsStr);
 		}
 


### PR DESCRIPTION
Sometimes the flags can end up being two digits; the previous code would
chop off the second digit by accident, giving very unexpected results for
the LIST flags.
