### PR TITLE
Added 64-bit NDK targets

### DIFF
--- a/platform/android/library/jni/Application.mk
+++ b/platform/android/library/jni/Application.mk
@@ -1,2 +1,2 @@
-APP_ABI := armeabi armeabi-v7a x86 mips
+APP_ABI := armeabi armeabi-v7a arm64-v8a x86 x86_64 mips mips64
 APP_STL := gnustl_static


### PR DESCRIPTION
There are now 64-bit targets on Android (starting with Nexus 9).
