### PR TITLE
Add mailto: to email addresses

### DIFF
--- a/platform/android/library/src/in/uncod/android/bypass/Bypass.java
+++ b/platform/android/library/src/in/uncod/android/bypass/Bypass.java
@@ -239,7 +239,11 @@ public class Bypass {
 				break;
 			case LINK:
 			case AUTOLINK:
-				setSpan(builder, new URLSpan(element.getAttribute("link")));
+				String link = element.getAttribute("link");
+				if (Patterns.EMAIL_ADDRESS.matcher(link).matches()) {
+					link = "mailto:" + link;
+				}
+				setSpan(builder, new URLSpan(link));
 				break;
 			case BLOCK_QUOTE:
 				// We add two leading margin spans so that when the order is reversed,


### PR DESCRIPTION
Android only knows how to handle emails in a `URLSpan` with a `mailto:` in front of the email address. This adds that for email addresses matched by `Patterns.EMAIL_ADDRESS`.
