### PR TITLE
Fix a crash rendering unordered lists

### DIFF
--- a/platform/android/library/src/in/uncod/android/bypass/Bypass.java
+++ b/platform/android/library/src/in/uncod/android/bypass/Bypass.java
@@ -102,10 +102,12 @@ public class Bypass {
 		boolean isOrderedList = false;
 		if (type == Type.LIST) {
 			String flagsStr = element.getAttribute("flags");
-			int flags = Integer.parseInt(flagsStr);
-			isOrderedList = (flags & Element.F_LIST_ORDERED) != 0;
-			if (isOrderedList) {
-				mOrderedListNumber.put(element, 1);
+			if (flagsStr != null) {
+				int flags = Integer.parseInt(flagsStr);
+				isOrderedList = (flags & Element.F_LIST_ORDERED) != 0;
+				if (isOrderedList) {
+					mOrderedListNumber.put(element, 1);
+				}
 			}
 		}
 


### PR DESCRIPTION
I'm getting a crash on Android when viewing unordered lists: Fatal Exception: java.lang.NumberFormatException Invalid int: "null" in.uncod.android.bypass.Bypass.recurseElement

This commit should fix it.
