### PR TITLE
Fixed possible IndexOutOfBoundsException

### DIFF
--- a/platform/android/library/src/in/uncod/android/bypass/Bypass.java
+++ b/platform/android/library/src/in/uncod/android/bypass/Bypass.java
@@ -293,7 +293,8 @@ public class Bypass {
 
 	// These have trailing newlines that we want to avoid spanning
 	private static void setBlockSpan(SpannableStringBuilder builder, Object what) {
-		builder.setSpan(what, 0, builder.length() - 1, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+		int length = Math.max(0, builder.length() - 1);
+		builder.setSpan(what, 0, length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
 	}
 
 	/**


### PR DESCRIPTION
Fixed a possible exception while generating a spannable string from your markdown input in android. This happens for example if you use a `>` followed by whitespace to begin a block quote.