### PR TITLE
Fix rendering of linebreaks in iOS 9

### DIFF
--- a/platform/ios/Bypass/Bypass/BPAttributedStringConverter.m
+++ b/platform/ios/Bypass/Bypass/BPAttributedStringConverter.m
@@ -136,7 +136,11 @@ NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
 
 - (void)insertLineSeparatorIntoTarget:(NSMutableAttributedString *)target
 {
-    [target appendAttributedString:[[NSMutableAttributedString alloc] initWithString:@"\u2028"]];
+    if (NSFoundationVersionNumber > NSFoundationVersionNumber_iOS_8_3) {
+        [target appendAttributedString:[[NSMutableAttributedString alloc] initWithString:@"\r"]];
+    } else {
+        [target appendAttributedString:[[NSMutableAttributedString alloc] initWithString:@"\u2028"]];
+    }
 }
 
 #pragma mark Span Element Rendering


### PR DESCRIPTION
Support for adding a linebreak instead of a linefeed using two trailing spaces followed by a newline that was added in PR #152 has broken with iOS 9.

This PR fixes that so that a linebreak is correctly rendered in iOS 9.
