### PR TITLE
Added support for RTL languages, correct list indentation

### DIFF
--- a/platform/ios/Bypass/Bypass/BPAttributedStringConverter.m
+++ b/platform/ios/Bypass/Bypass/BPAttributedStringConverter.m
@@ -261,7 +261,7 @@ NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
     [paragraphStyle setFirstLineHeadIndent:[_displaySettings quoteIndentation]];
     [paragraphStyle setHeadIndent:[_displaySettings quoteIndentation]];
     [paragraphStyle setTailIndent:-[_displaySettings quoteIndentation]];
-	[paragraphStyle setAlignment:_displaySettings.textAlignment];
+		[paragraphStyle setAlignment:_displaySettings.textAlignment];
     attributes[NSParagraphStyleAttributeName] = paragraphStyle;
     
     [target addAttributes:attributes range:effectiveRange];
@@ -280,7 +280,7 @@ NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
     [paragraphStyle setFirstLineHeadIndent:[_displaySettings codeIndentation]];
     [paragraphStyle setHeadIndent:[_displaySettings codeIndentation]];
     [paragraphStyle setTailIndent:-[_displaySettings codeIndentation]];
-	[paragraphStyle setAlignment:_displaySettings.textAlignment];
+		[paragraphStyle setAlignment:_displaySettings.textAlignment];
     attributes[NSParagraphStyleAttributeName] = paragraphStyle;
     
     [target addAttributes:attributes range:effectiveRange];
@@ -313,12 +313,10 @@ NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
 {
     NSUInteger level = 0;
     BPElement *inspectedElement = [[element parentElement] parentElement];
-	//NSMutableString *indentation = [NSMutableString  string];
-    
+	
     while ([inspectedElement elementType] == BPList
            || [inspectedElement elementType] == BPListItem) {
         if ([inspectedElement elementType] == BPList) {
-					//[indentation appendString:@"\u200B"];
             ++level;
         }
         
@@ -352,9 +350,9 @@ NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
     
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
     [paragraphStyle setLineSpacing:[_displaySettings lineSpacingSmall]];
-	[paragraphStyle setAlignment:_displaySettings.textAlignment];
-	[paragraphStyle setHeadIndent:24*(level)+14];
-	[paragraphStyle setFirstLineHeadIndent:24*(level)];
+		[paragraphStyle setAlignment:_displaySettings.textAlignment];
+		[paragraphStyle setHeadIndent:24*(level)+14];
+		[paragraphStyle setFirstLineHeadIndent:24*(level)];
 
     
     NSDictionary *indentationAttributes = @{
@@ -383,7 +381,7 @@ NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
     [paragraphStyle setLineSpacing:[_displaySettings paragraphLineSpacingHeading]];
     [paragraphStyle setFirstLineHeadIndent:[_displaySettings headerFirstLineHeadIndent]];
     [paragraphStyle setHeadIndent:[_displaySettings headerHeadIndent]];
-	[paragraphStyle setAlignment:_displaySettings.textAlignment];
+	  [paragraphStyle setAlignment:_displaySettings.textAlignment];
     attributes[NSParagraphStyleAttributeName] = paragraphStyle;
     
     // Override font weight and size attributes (but preserve all other attributes)

--- a/platform/ios/Bypass/Bypass/BPAttributedStringConverter.m
+++ b/platform/ios/Bypass/Bypass/BPAttributedStringConverter.m
@@ -261,6 +261,7 @@ NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
     [paragraphStyle setFirstLineHeadIndent:[_displaySettings quoteIndentation]];
     [paragraphStyle setHeadIndent:[_displaySettings quoteIndentation]];
     [paragraphStyle setTailIndent:-[_displaySettings quoteIndentation]];
+	[paragraphStyle setAlignment:_displaySettings.textAlignment];
     attributes[NSParagraphStyleAttributeName] = paragraphStyle;
     
     [target addAttributes:attributes range:effectiveRange];
@@ -279,6 +280,7 @@ NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
     [paragraphStyle setFirstLineHeadIndent:[_displaySettings codeIndentation]];
     [paragraphStyle setHeadIndent:[_displaySettings codeIndentation]];
     [paragraphStyle setTailIndent:-[_displaySettings codeIndentation]];
+	[paragraphStyle setAlignment:_displaySettings.textAlignment];
     attributes[NSParagraphStyleAttributeName] = paragraphStyle;
     
     [target addAttributes:attributes range:effectiveRange];
@@ -293,6 +295,7 @@ NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
     [paragraphStyle setParagraphSpacing:[_displaySettings paragraphSpacing]];
     [paragraphStyle setLineSpacing:[_displaySettings paragraphLineSpacing]];
     [paragraphStyle setFirstLineHeadIndent:[_displaySettings paragraphFirstLineHeadIndent]];
+	[paragraphStyle setAlignment:_displaySettings.textAlignment];
 
     if(!self.renderedFirstParagraph) {
         [paragraphStyle setFirstLineHeadIndent:[_displaySettings firstParagraphFirstLineHeadIndent]];
@@ -310,12 +313,12 @@ NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
 {
     NSUInteger level = 0;
     BPElement *inspectedElement = [[element parentElement] parentElement];
-    NSMutableString *indentation = [NSMutableString  string];
+	//NSMutableString *indentation = [NSMutableString  string];
     
     while ([inspectedElement elementType] == BPList
            || [inspectedElement elementType] == BPListItem) {
         if ([inspectedElement elementType] == BPList) {
-            [indentation appendString:@"\t"];
+					//[indentation appendString:@"\u200B"];
             ++level;
         }
         
@@ -349,6 +352,10 @@ NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
     
     NSMutableParagraphStyle *paragraphStyle = [[NSMutableParagraphStyle alloc] init];
     [paragraphStyle setLineSpacing:[_displaySettings lineSpacingSmall]];
+	[paragraphStyle setAlignment:_displaySettings.textAlignment];
+	[paragraphStyle setHeadIndent:24*(level)+14];
+	[paragraphStyle setFirstLineHeadIndent:24*(level)];
+
     
     NSDictionary *indentationAttributes = @{
         NSFontAttributeName : [UIFont systemFontOfSize:[_displaySettings bulletIndentation]],
@@ -356,7 +363,7 @@ NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
     };
     
     NSAttributedString *attributedIndentation;
-    attributedIndentation = [[NSAttributedString alloc] initWithString:indentation
+    attributedIndentation = [[NSAttributedString alloc] initWithString:@"\u200B"
                                                             attributes:indentationAttributes];
     [target insertAttributedString:attributedIndentation atIndex:effectiveRange.location];
 
@@ -376,6 +383,7 @@ NSString *const BPLinkStyleAttributeName = @"NSLinkAttributeName";
     [paragraphStyle setLineSpacing:[_displaySettings paragraphLineSpacingHeading]];
     [paragraphStyle setFirstLineHeadIndent:[_displaySettings headerFirstLineHeadIndent]];
     [paragraphStyle setHeadIndent:[_displaySettings headerHeadIndent]];
+	[paragraphStyle setAlignment:_displaySettings.textAlignment];
     attributes[NSParagraphStyleAttributeName] = paragraphStyle;
     
     // Override font weight and size attributes (but preserve all other attributes)

--- a/platform/ios/Bypass/Bypass/BPDisplaySettings.h
+++ b/platform/ios/Bypass/Bypass/BPDisplaySettings.h
@@ -51,4 +51,6 @@
 @property(nonatomic) CGFloat headerFirstLineHeadIndent;
 @property(nonatomic) CGFloat headerHeadIndent;
 
+@property(nonatomic) NSTextAlignment textAlignment;
+
 @end

--- a/platform/ios/Bypass/Bypass/BPDisplaySettings.h
+++ b/platform/ios/Bypass/Bypass/BPDisplaySettings.h
@@ -51,6 +51,8 @@
 @property(nonatomic) CGFloat headerFirstLineHeadIndent;
 @property(nonatomic) CGFloat headerHeadIndent;
 
+// used to add text alignment to blocks if 'Natural' is not right (e.g. the text is known to be right-to-left
+// on a left-to-right device.)
 @property(nonatomic) NSTextAlignment textAlignment;
 
 @end

--- a/platform/ios/Bypass/Bypass/BPDisplaySettings.m
+++ b/platform/ios/Bypass/Bypass/BPDisplaySettings.m
@@ -44,6 +44,7 @@
 
     self.paragraphLineSpacing = 1.2f;
     self.paragraphLineSpacingHeading = 1.2f;
+		self.textAlignment = NSTextAlignmentNatural;
 
   }
   return self;


### PR DESCRIPTION
# RTL Languages
I added

    @property(nonatomic) NSTextAlignment textAlignment;

to the `BPDisplaySettings`, so the system's default (Natural) may be overridden in case the content is known to contain a right-to-left language on a left-to-right device.

The setting get's interpreted when styling the paragraphs in the `BPAttributedStringConverter` and defaults to `NSTextAlignmentNatural`, the system default.

# Correct list indentation
When list items run over more than one line, the broken lines should be indented so they start where the first line starts; after the bullet and the space.

For that to work, instead of inserting tab characters before the list item to match the level, I insert the zero-width character for all levels and apply the correct indentations for the level to the paragraph style. 

As the bullet uses a monospace font and (afais) cannot be configured, this should work for any settings.
 

