### PR TITLE
Add title element to the website

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
 	<head>
+		<title>Bypass by Uncodin &middot; Skip the HTML, Bypass takes markdown and renders it directly on Android and iOS.</title>
 		<link rel="icon" href="favicon.ico" type="image/x-icon" />
 		<link rel="stylesheet" type="text/css" href="styles.css" />
 	</head>


### PR DESCRIPTION
- Without the title element, the tab shows the truncated URL, which doesn't look nice.