### PR TITLE
Added ProGuard rule to android docs

### DIFF
--- a/platform/android/README.md
+++ b/platform/android/README.md
@@ -7,6 +7,13 @@
 	text.setText(string);
 	text.setMovementMethod(LinkMovementMethod.getInstance());
 
+### ProGuard
+
+If you are using ProGuard you might need to add the following options:
+```
+-keep class in.uncod.android.** { *; }
+```
+
 ### Maven Dependency
 If you just want to include Bypass in your Maven project, add the following
 dependency block to your `pom.xml`:


### PR DESCRIPTION
Proguard automatically renames the file classes after building. Since this rule is crucial in order to use in a release (to prevent crashes) it is good to add it to the documentation.